### PR TITLE
🩹 Ignore DeprecationWarning in Qiskit code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,8 +101,7 @@ log_cli_level = "INFO"
 xfail_strict = true
 filterwarnings = [
     "error",
-    # See https://github.com/Qiskit/rustworkx/pull/728
-    'ignore:RetworkxLoader.exec_module\(\) not found; falling back to load_module\(\):ImportWarning',
+    'ignore:.*`product` is deprecated.*:DeprecationWarning:qiskit:',
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
## Description

An update in numpy has triggered a DeprecationWarning in Qiskit code that now trips up in our tests.
This PR ignores the respective warning as it does not concern us.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
