### PR TITLE
🩹 patch CI failure due to unconditional Qiskit deprecation warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ xfail_strict = true
 filterwarnings = [
     "error",
     'ignore:.*`product` is deprecated.*:DeprecationWarning:qiskit:',
+    'ignore:.*qiskit.__qiskit_version__.*:DeprecationWarning:qiskit:',
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
## Description

Fixes CI. The newest Qiskit version introduced a new deprecation warning for some version attribute and, for some reason, that warning trips up pytest without our code actually using the deprecated attribute.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
