### PR TITLE
🐛 Fix a div-by-zero in `Proportional` strategy for empty circuit 

### DIFF
--- a/include/checker/dd/applicationscheme/ProportionalApplicationScheme.hpp
+++ b/include/checker/dd/applicationscheme/ProportionalApplicationScheme.hpp
@@ -32,6 +32,6 @@ private:
                     static_cast<std::size_t>(1U));
   }
 
-  const std::size_t gateRatio;
+  std::size_t gateRatio;
 };
 } // namespace ec

--- a/include/checker/dd/applicationscheme/ProportionalApplicationScheme.hpp
+++ b/include/checker/dd/applicationscheme/ProportionalApplicationScheme.hpp
@@ -25,6 +25,9 @@ private:
   [[nodiscard]] std::size_t computeGateRatio() const noexcept {
     const std::size_t size1 = this->taskManager1.getCircuit()->size();
     const std::size_t size2 = this->taskManager2.getCircuit()->size();
+    if (size1 == 0U) {
+      return size2;
+    }
     return std::max((size2 + (size1 / 2U)) / size1,
                     static_cast<std::size_t>(1U));
   }

--- a/src/EquivalenceCheckingManager.cpp
+++ b/src/EquivalenceCheckingManager.cpp
@@ -157,6 +157,12 @@ void EquivalenceCheckingManager::run() {
     return;
   }
 
+  if (qc1.empty() && qc2.empty()) {
+    results.equivalence = EquivalenceCriterion::Equivalent;
+    done                = true;
+    return;
+  }
+
   if (qc1.isVariableFree() && qc2.isVariableFree()) {
     if (!configuration.execution.parallel ||
         configuration.execution.nthreads <= 1 ||

--- a/test/test_equality.cpp
+++ b/test/test_equality.cpp
@@ -179,3 +179,83 @@ TEST_F(EqualityTest, ExceptionInParallelThread) {
   ec::EquivalenceCheckingManager ecm(qc1, qc1, config);
   EXPECT_THROW(ecm.run(), std::invalid_argument);
 }
+
+TEST_F(EqualityTest, BothCircuitsEmptyAlternatingChecker) {
+  config.execution.runAlternatingChecker = true;
+  ec::EquivalenceCheckingManager ecm(qc1, qc2, config);
+  ecm.setApplicationScheme(ec::ApplicationSchemeType::Proportional);
+  ecm.run();
+  EXPECT_EQ(ecm.equivalence(), ec::EquivalenceCriterion::Equivalent);
+}
+
+TEST_F(EqualityTest, BothCircuitsEmptyConstructionChecker) {
+  config.execution.runConstructionChecker = true;
+  ec::EquivalenceCheckingManager ecm(qc1, qc2, config);
+  ecm.setApplicationScheme(ec::ApplicationSchemeType::Proportional);
+  ecm.run();
+  EXPECT_EQ(ecm.equivalence(), ec::EquivalenceCriterion::Equivalent);
+}
+
+TEST_F(EqualityTest, BothCircuitsEmptySimulationChecker) {
+  config.execution.runSimulationChecker = true;
+  ec::EquivalenceCheckingManager ecm(qc1, qc2, config);
+  ecm.setApplicationScheme(ec::ApplicationSchemeType::Proportional);
+  ecm.run();
+  EXPECT_EQ(ecm.equivalence(), ec::EquivalenceCriterion::Equivalent);
+}
+
+TEST_F(EqualityTest, BothCircuitsEmptyZXChecker) {
+  config.execution.runZXChecker = true;
+  ec::EquivalenceCheckingManager ecm(qc1, qc2, config);
+  ecm.setApplicationScheme(ec::ApplicationSchemeType::Proportional);
+  ecm.run();
+  EXPECT_EQ(ecm.equivalence(), ec::EquivalenceCriterion::Equivalent);
+}
+
+TEST_F(EqualityTest, OneCircuitEmptyAlternatingChecker) {
+  qc2.h(0);
+  qc2.x(0);
+  qc2.h(0);
+  qc2.z(0);
+  config.execution.runAlternatingChecker = true;
+  ec::EquivalenceCheckingManager ecm(qc1, qc2, config);
+  ecm.setApplicationScheme(ec::ApplicationSchemeType::Proportional);
+  ecm.run();
+  EXPECT_EQ(ecm.equivalence(), ec::EquivalenceCriterion::Equivalent);
+}
+
+TEST_F(EqualityTest, OneCircuitEmptyConstructionChecker) {
+  qc2.h(0);
+  qc2.x(0);
+  qc2.h(0);
+  qc2.z(0);
+  config.execution.runConstructionChecker = true;
+  ec::EquivalenceCheckingManager ecm(qc1, qc2, config);
+  ecm.setApplicationScheme(ec::ApplicationSchemeType::Proportional);
+  ecm.run();
+  EXPECT_EQ(ecm.equivalence(), ec::EquivalenceCriterion::Equivalent);
+}
+
+TEST_F(EqualityTest, OneCircuitEmptySimulationChecker) {
+  qc2.h(0);
+  qc2.x(0);
+  qc2.h(0);
+  qc2.z(0);
+  config.execution.runSimulationChecker = true;
+  ec::EquivalenceCheckingManager ecm(qc1, qc2, config);
+  ecm.setApplicationScheme(ec::ApplicationSchemeType::Proportional);
+  ecm.run();
+  EXPECT_EQ(ecm.equivalence(), ec::EquivalenceCriterion::ProbablyEquivalent);
+}
+
+TEST_F(EqualityTest, OneCircuitEmptyZXChecker) {
+  qc2.h(0);
+  qc2.x(0);
+  qc2.h(0);
+  qc2.z(0);
+  config.execution.runZXChecker = true;
+  ec::EquivalenceCheckingManager ecm(qc1, qc2, config);
+  ecm.setApplicationScheme(ec::ApplicationSchemeType::Proportional);
+  ecm.run();
+  EXPECT_EQ(ecm.equivalence(), ec::EquivalenceCriterion::Equivalent);
+}


### PR DESCRIPTION
## Description

This PR fixes a corner case where an empty circuit could lead to a division by zero error when trying to compute the gate ration between both circuits.
Furthermore, a shortcut is added for when both circuits are empty.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
