### PR TITLE
⬆️ update `scikit-build-core`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -124,6 +124,6 @@ repos:
       - id: check-sdist
         args: [--inject-junk]
         additional_dependencies:
-          - scikit-build-core[pyproject]>=0.5.0,<0.6 # TODO: remove upper cap once scikit-build-core is updated
+          - scikit-build-core[pyproject]>=0.6.1
           - setuptools-scm>=7
           - pybind11>=2.11

--- a/noxfile.py
+++ b/noxfile.py
@@ -16,6 +16,12 @@ nox.options.sessions = ["lint", "pylint", "tests"]
 
 PYTHON_ALL_VERSIONS = ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
+BUILD_REQUIREMENTS = [
+    "scikit-build-core[pyproject]>=0.6.1",
+    "setuptools_scm>=7",
+    "pybind11>=2.11",
+]
+
 if os.environ.get("CI", None):
     nox.options.error_on_missing_interpreters = True
 
@@ -36,9 +42,7 @@ def pylint(session: nox.Session) -> None:
 
     Simply execute `nox -rs pylint` to run PyLint.
     """
-    session.install(
-        "scikit-build-core[pyproject]<0.6", "setuptools_scm", "pybind11"
-    )  # TODO: remove upper cap once scikit-build-core is updated
+    session.install(*BUILD_REQUIREMENTS)
     session.install("--no-build-isolation", "-ve.", "pylint")
     session.run("pylint", "mqt.qcec", *session.posargs)
 
@@ -61,9 +65,7 @@ def _run_tests(
         _extras.append("coverage")
         posargs.append("--cov-config=pyproject.toml")
 
-    session.install(
-        "scikit-build-core[pyproject]<0.6", "setuptools_scm", "pybind11", *install_args, env=env
-    )  # TODO: remove upper cap once scikit-build-core is updated
+    session.install(*BUILD_REQUIREMENTS, *install_args, env=env)
     install_arg = f"-ve.[{','.join(_extras)}]"
     session.install("--no-build-isolation", install_arg, *install_args, env=env)
     session.run("pytest", *run_args, *posargs, env=env)
@@ -97,13 +99,8 @@ def docs(session: nox.Session) -> None:
     if args.builder != "html" and args.serve:
         session.error("Must not specify non-HTML builder with --serve")
 
-    build_requirements = [
-        "scikit-build-core[pyproject]<0.6",
-        "setuptools_scm",
-        "pybind11",
-    ]  # TODO: remove upper cap once scikit-build-core is updated
     extra_installs = ["sphinx-autobuild"] if args.serve else []
-    session.install(*build_requirements, *extra_installs)
+    session.install(*BUILD_REQUIREMENTS, *extra_installs)
     session.install("--no-build-isolation", "-ve.[docs]")
     session.chdir("docs")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [build-system]
-# TODO: remove upper cap once scikit-build-core is updated
-requires = ["scikit-build-core>=0.5.0,<0.6.0", "setuptools-scm>=7", "pybind11>=2.11"]
+requires = ["scikit-build-core>=0.6.1", "setuptools-scm>=7", "pybind11>=2.11"]
 build-backend = "scikit_build_core.build"
 
 [project]
@@ -71,7 +70,7 @@ Discussions = "https://github.com/cda-tum/mqt-qcec/discussions"
 
 [tool.scikit-build]
 # Protect the configuration against future changes in scikit-build-core
-minimum-version = "0.5.0"
+minimum-version = "0.6.1"
 
 # Set the target to build
 cmake.targets = ["pyqcec"]
@@ -214,6 +213,7 @@ extend-select = [
 ]
 extend-ignore = [
     "ANN101",  # Missing type annotation for self in method
+    "ISC001",  # Conflicts with formatter
     "PLR",     # Design related pylint codes
 ]
 isort.required-imports = ["from __future__ import annotations"]

--- a/test/python/constraints.txt
+++ b/test/python/constraints.txt
@@ -1,4 +1,4 @@
-scikit-build-core==0.5.0
+scikit-build-core==0.6.1
 setuptools-scm==7.0.0
 pybind11==2.11.0
 pytest==7.0.0


### PR DESCRIPTION
## Description

This PR updates `scikit-build-core` to the latest version and drops the upper cap that was temporarily put in place.
Additionally, it simplifies the noxfile configuration a little bit to eliminate some redundancy and set lower bounds on the build time dependencies.
This ensures that a bump in the minimum required version of a build dependency will also be directly accounted for in nox sessions.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
