### PR TITLE
✨ Better dynamic circuit support

### DIFF
--- a/include/Configuration.hpp
+++ b/include/Configuration.hpp
@@ -39,6 +39,7 @@ public:
     bool removeDiagonalGatesBeforeMeasure = false;
     bool transformDynamicCircuit          = false;
     bool reorderOperations                = true;
+    bool backpropagateOutputPermutation   = false;
   };
 
   // configuration options for application schemes
@@ -157,6 +158,8 @@ public:
         optimizations.removeDiagonalGatesBeforeMeasure;
     opt["transform_dynamic_circuit"] = optimizations.transformDynamicCircuit;
     opt["reorder_operations"]        = optimizations.reorderOperations;
+    opt["backpropagate_output_permutation"] =
+        optimizations.backpropagateOutputPermutation;
 
     auto& app = config["application"];
     if (execution.runConstructionChecker) {

--- a/include/EquivalenceCheckingManager.hpp
+++ b/include/EquivalenceCheckingManager.hpp
@@ -130,6 +130,7 @@ public:
   void fuseSingleQubitGates();
   void reconstructSWAPs();
   void reorderOperations();
+  void backpropagateOutputPermutation();
 
   // Application: These settings may be changed to influence the sequence in
   // which gates are applied during the equivalence check

--- a/src/EquivalenceCheckingManager.cpp
+++ b/src/EquivalenceCheckingManager.cpp
@@ -142,6 +142,11 @@ void EquivalenceCheckingManager::runOptimizationPasses() {
     qc::CircuitOptimizer::reorderOperations(qc2);
   }
 
+  if (configuration.optimizations.backpropagateOutputPermutation) {
+    qc::CircuitOptimizer::backpropagateOutputPermutation(qc1);
+    qc::CircuitOptimizer::backpropagateOutputPermutation(qc2);
+  }
+
   // remove final measurements from both circuits so that the underlying
   // functionality should be unitary
   qc::CircuitOptimizer::removeFinalMeasurements(qc1);
@@ -746,12 +751,14 @@ nlohmann::json EquivalenceCheckingManager::json() const {
   }
   return res;
 }
+
 void EquivalenceCheckingManager::runFixOutputPermutationMismatch() {
   if (!configuration.optimizations.fixOutputPermutationMismatch) {
     fixOutputPermutationMismatch();
     configuration.optimizations.fixOutputPermutationMismatch = true;
   }
 }
+
 void EquivalenceCheckingManager::fuseSingleQubitGates() {
   if (!configuration.optimizations.fuseSingleQubitGates) {
     qc::CircuitOptimizer::singleQubitGateFusion(qc1);
@@ -759,6 +766,7 @@ void EquivalenceCheckingManager::fuseSingleQubitGates() {
     configuration.optimizations.fuseSingleQubitGates = true;
   }
 }
+
 void EquivalenceCheckingManager::reconstructSWAPs() {
   if (!configuration.optimizations.reconstructSWAPs) {
     qc::CircuitOptimizer::swapReconstruction(qc1);
@@ -766,6 +774,7 @@ void EquivalenceCheckingManager::reconstructSWAPs() {
     configuration.optimizations.reconstructSWAPs = true;
   }
 }
+
 void EquivalenceCheckingManager::reorderOperations() {
   if (!configuration.optimizations.reorderOperations) {
     qc::CircuitOptimizer::reorderOperations(qc1);
@@ -773,6 +782,15 @@ void EquivalenceCheckingManager::reorderOperations() {
     configuration.optimizations.reorderOperations = true;
   }
 }
+
+void EquivalenceCheckingManager::backpropagateOutputPermutation() {
+  if (!configuration.optimizations.backpropagateOutputPermutation) {
+    qc::CircuitOptimizer::backpropagateOutputPermutation(qc1);
+    qc::CircuitOptimizer::backpropagateOutputPermutation(qc2);
+    configuration.optimizations.backpropagateOutputPermutation = true;
+  }
+}
+
 nlohmann::json EquivalenceCheckingManager::Results::json() const {
   nlohmann::json res{};
   res["preprocessing_time"] = preprocessingTime;

--- a/src/mqt/qcec/configuration.py
+++ b/src/mqt/qcec/configuration.py
@@ -33,6 +33,7 @@ class ConfigurationOptions(TypedDict, total=False):
     # Functionality
     trace_threshold: float
     # Optimizations
+    backpropagate_output_permutation: bool
     fix_output_permutation_mismatch: bool
     fuse_single_qubit_gates: bool
     reconstruct_swaps: bool

--- a/src/mqt/qcec/pyqcec.pyi
+++ b/src/mqt/qcec/pyqcec.pyi
@@ -2,7 +2,7 @@ from typing import Any, ClassVar, overload
 
 from qiskit import QuantumCircuit
 
-from mqt.qcec.types import ApplicationSchemeName, EquivalenceCriterionName, StateTypeName
+from .types import ApplicationSchemeName, EquivalenceCriterionName, StateTypeName
 
 class ApplicationScheme:
     __members__: ClassVar[dict[ApplicationScheme, int]] = ...  # read-only
@@ -51,6 +51,7 @@ class Configuration:
         def __init__(self) -> None: ...
 
     class Optimizations:
+        backpropagate_output_permutation: bool
         fix_output_permutation_mismatch: bool
         fuse_single_qubit_gates: bool
         reconstruct_swaps: bool
@@ -99,6 +100,7 @@ class EquivalenceCheckingManager:
     def __init__(
         self, circ1: QuantumCircuit | str, circ2: QuantumCircuit | str, config: Configuration = ...
     ) -> None: ...
+    def backpropagate_output_permutation(self) -> None: ...
     def disable_all_checkers(self) -> None: ...
     def equivalence(self) -> EquivalenceCriterion: ...
     def fix_output_permutation_mismatch(self) -> None: ...

--- a/src/python/bindings.cpp
+++ b/src/python/bindings.cpp
@@ -246,6 +246,11 @@ PYBIND11_MODULE(pyqcec, m) {
            ":attr:`Reorder operations "
            "<.Configuration.Optimizations.reorder_operations>` to establish "
            "canonical ordering.")
+      .def("backpropagate_output_permutation",
+           &EquivalenceCheckingManager::backpropagateOutputPermutation,
+           ":attr:`Backpropagate the output permutation "
+           "<.Configuration.Optimizations.backpropagate_output_permutation>` "
+           "to the input permutation.")
       // Application
       .def("set_application_scheme",
            &EquivalenceCheckingManager::setApplicationScheme,
@@ -545,7 +550,17 @@ PYBIND11_MODULE(pyqcec, m) {
           "a different order. This optimization pass established a canonical "
           "ordering of operations by, first, constructing a directed, acyclic "
           "graph for the operations and, then, traversing it in a "
-          "breadth-first fashion. Defaults to :code:`True`.");
+          "breadth-first fashion. Defaults to :code:`True`.")
+      .def_readwrite(
+          "backpropagate_output_permutation",
+          &Configuration::Optimizations::backpropagateOutputPermutation,
+          "Backpropagate the output permutation to the input permutation. "
+          "Defaults to :code:`False` since this might mess up the initially "
+          "given input permutation. Can be helpful for dynamic quantum circuits"
+          " that have been transformed to a static circuit by enabling the "
+          ":attr:`transform_dynamic_circuit "
+          "<.Configuration.Optimizations.transform_dynamic_circuit>` "
+          "optimization.");
 
   // application options
   application.def(py::init<>())

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,6 +15,7 @@ package_add_test(
   legacy/test_compilationflow.cpp
   legacy/test_general.cpp
   legacy/test_simulation.cpp
+  test_dynamic_circuits.cpp
   test_simple_circuit_identities.cpp
   test_gate_cost_application_scheme.cpp
   test_equality.cpp

--- a/test/legacy/test_general.cpp
+++ b/test/legacy/test_general.cpp
@@ -25,7 +25,8 @@ TEST_F(GeneralTest, DynamicCircuit) {
   EXPECT_THROW(ec::EquivalenceCheckingManager(bv, dbv, config),
                std::runtime_error);
 
-  config.optimizations.transformDynamicCircuit = true;
+  config.optimizations.transformDynamicCircuit        = true;
+  config.optimizations.backpropagateOutputPermutation = true;
 
   auto ecm = ec::EquivalenceCheckingManager(bv, dbv, config);
 

--- a/test/legacy/test_general.cpp
+++ b/test/legacy/test_general.cpp
@@ -33,7 +33,7 @@ TEST_F(GeneralTest, DynamicCircuit) {
 
   EXPECT_TRUE(ecm.getResults().consideredEquivalent());
 
-  std::cout << ecm.toString() << std::endl;
+  std::cout << ecm.toString() << "\n";
 
   auto ecm2 = ec::EquivalenceCheckingManager(dbv, dbv, config);
 
@@ -41,7 +41,7 @@ TEST_F(GeneralTest, DynamicCircuit) {
 
   EXPECT_TRUE(ecm2.getResults().consideredEquivalent());
 
-  std::cout << ecm2.toString() << std::endl;
+  std::cout << ecm2.toString() << "\n";
 }
 
 TEST_F(GeneralTest, FixOutputPermutationMismatch) {
@@ -49,7 +49,7 @@ TEST_F(GeneralTest, FixOutputPermutationMismatch) {
   qc1.x(0);
   qc1.x(1);
   qc1.setLogicalQubitAncillary(1);
-  std::cout << qc1 << std::endl;
+  std::cout << qc1 << "\n";
 
   qc2.addQubitRegister(3U);
   qc2.x(0);
@@ -59,8 +59,8 @@ TEST_F(GeneralTest, FixOutputPermutationMismatch) {
   qc2.outputPermutation.erase(1);
   qc2.setLogicalQubitAncillary(1);
   qc2.setLogicalQubitGarbage(1);
-  std::cout << static_cast<int>(qc2.getNqubits()) << std::endl;
-  std::cout << qc2 << std::endl;
+  std::cout << static_cast<int>(qc2.getNqubits()) << "\n";
+  std::cout << qc2 << "\n";
 
   auto config                                       = ec::Configuration{};
   config.optimizations.fixOutputPermutationMismatch = true;
@@ -80,22 +80,22 @@ TEST_F(GeneralTest, RemoveDiagonalGatesBeforeMeasure) {
   qc1.addClassicalRegister(1U);
   qc1.x(0);
   qc1.measure(0, 0U);
-  std::cout << qc1 << std::endl;
-  std::cout << "-----------------------------" << std::endl;
+  std::cout << qc1 << "\n";
+  std::cout << "-----------------------------\n";
 
   qc2.addQubitRegister(1U);
   qc2.addClassicalRegister(1U);
   qc2.x(0);
   qc2.z(0);
   qc2.measure(0, 0U);
-  std::cout << qc2 << std::endl;
-  std::cout << "-----------------------------" << std::endl;
+  std::cout << qc2 << "\n";
+  std::cout << "-----------------------------\n";
 
   // the standard check should reveal that both circuits are not equivalent
   auto ecm = ec::EquivalenceCheckingManager(qc1, qc2);
   ecm.run();
   EXPECT_FALSE(ecm.getResults().consideredEquivalent());
-  std::cout << ecm.toString() << std::endl;
+  std::cout << ecm.toString() << "\n";
 
   // simulations should suggest both circuits to be equivalent
   ecm.reset();
@@ -103,7 +103,7 @@ TEST_F(GeneralTest, RemoveDiagonalGatesBeforeMeasure) {
   ecm.setZXChecker(false);
   ecm.run();
   EXPECT_TRUE(ecm.getResults().consideredEquivalent());
-  std::cout << ecm.toString() << std::endl;
+  std::cout << ecm.toString() << "\n";
 
   // if configured to remove diagonal gates before measurements, the circuits
   // are equivalent
@@ -112,7 +112,7 @@ TEST_F(GeneralTest, RemoveDiagonalGatesBeforeMeasure) {
   auto ecm2 = ec::EquivalenceCheckingManager(qc1, qc2, config);
   ecm2.run();
   EXPECT_TRUE(ecm2.getResults().consideredEquivalent());
-  std::cout << ecm2.toString() << std::endl;
+  std::cout << ecm2.toString() << "\n";
 }
 
 TEST_F(GeneralTest, NothingToDo) {
@@ -181,5 +181,5 @@ TEST_F(GeneralTest, NoGateCancellation) {
   ec::EquivalenceCheckingManager ecm(qc1, qc2, config);
   ecm.run();
   EXPECT_TRUE(ecm.getResults().consideredEquivalent());
-  std::cout << ecm.toString() << std::endl;
+  std::cout << ecm.toString() << "\n";
 }

--- a/test/python/test_dynamic_circuits.py
+++ b/test/python/test_dynamic_circuits.py
@@ -1,0 +1,98 @@
+"""Tests the dynamic quantum circuit support of QCEC."""
+
+from __future__ import annotations
+
+from qiskit import QuantumCircuit
+
+from mqt import qcec
+
+
+def test_regression1() -> None:
+    """Test a regression from https://github.com/cda-tum/mqt-qcec/issues/343."""
+    qc = QuantumCircuit(5)
+    qc.cx(1, 2)
+    qc.cx(0, 3)
+    qc.cx(1, 4)
+    qc.cx(2, 4)
+    qc.cx(3, 4)
+    qc.measure_all()
+
+    qc_dyn = QuantumCircuit(3, 5)
+    qc_dyn.cx(0, 1)
+    qc_dyn.cx(0, 2)
+    qc_dyn.measure(0, 1)
+    qc_dyn.reset(0)
+
+    qc_dyn.cx(1, 2)
+    qc_dyn.measure(1, 2)
+    qc_dyn.reset(1)
+
+    qc_dyn.cx(0, 1)
+    qc_dyn.measure(0, 0)
+
+    qc_dyn.cx(1, 2)
+    qc_dyn.measure(1, 3)
+    qc_dyn.measure(2, 4)
+
+    result = qcec.verify(qc, qc_dyn, transform_dynamic_circuit=True, backpropagate_output_permutation=True)
+    assert result.equivalence == qcec.EquivalenceCriterion.equivalent
+
+
+def test_regression2() -> None:
+    """Test a regression from https://github.com/cda-tum/mqt-qcec/issues/343."""
+    qc = QuantumCircuit(9)
+    qc.h(range(9))
+    qc.z(8)
+    qc.cx(0, 8)
+    qc.cx(1, 8)
+    qc.cx(3, 8)
+    qc.cx(5, 8)
+    qc.cx(6, 8)
+    qc.cx(7, 8)
+    qc.h(range(8))
+    qc.measure_all()
+
+    qc_dyn = QuantumCircuit(2, 9)
+    qc_dyn.h(0)
+    qc_dyn.h(0)
+    qc_dyn.measure(0, 2)
+    qc_dyn.reset(0)
+    qc_dyn.h(0)
+    qc_dyn.h(0)
+    qc_dyn.measure(0, 4)
+    qc_dyn.reset(0)
+    qc_dyn.h(0)
+    qc_dyn.h(1)
+    qc_dyn.z(1)
+    qc_dyn.cx(0, 1)
+    qc_dyn.h(0)
+    qc_dyn.measure(0, 0)
+    qc_dyn.reset(0)
+    qc_dyn.h(0)
+    qc_dyn.cx(0, 1)
+    qc_dyn.h(0)
+    qc_dyn.measure(0, 1)
+    qc_dyn.reset(0)
+    qc_dyn.h(0)
+    qc_dyn.cx(0, 1)
+    qc_dyn.h(0)
+    qc_dyn.measure(0, 3)
+    qc_dyn.reset(0)
+    qc_dyn.h(0)
+    qc_dyn.cx(0, 1)
+    qc_dyn.h(0)
+    qc_dyn.measure(0, 5)
+    qc_dyn.reset(0)
+    qc_dyn.h(0)
+    qc_dyn.cx(0, 1)
+    qc_dyn.h(0)
+    qc_dyn.measure(0, 6)
+    qc_dyn.reset(0)
+    qc_dyn.h(0)
+    qc_dyn.cx(0, 1)
+    qc_dyn.measure(1, 8)
+    qc_dyn.h(0)
+    qc_dyn.measure(0, 7)
+
+    result = qcec.verify(qc, qc_dyn, transform_dynamic_circuit=True, backpropagate_output_permutation=True)
+    assert result.equivalence == qcec.EquivalenceCriterion.equivalent

--- a/test/test_dynamic_circuits.cpp
+++ b/test/test_dynamic_circuits.cpp
@@ -1,0 +1,299 @@
+#include "EquivalenceCheckingManager.hpp"
+#include "algorithms/BernsteinVazirani.hpp"
+#include "algorithms/QFT.hpp"
+#include "algorithms/QPE.hpp"
+
+#include <bitset>
+#include <gtest/gtest.h>
+#include <iomanip>
+#include <string>
+#include <utility>
+
+class DynamicCircuitTestExactQPE : public testing::TestWithParam<std::size_t> {
+protected:
+  std::size_t                             precision{};
+  qc::fp                                  theta{};
+  std::size_t                             expectedResult{};
+  std::string                             expectedResultRepresentation{};
+  std::unique_ptr<qc::QuantumComputation> qpe;
+  std::unique_ptr<qc::QuantumComputation> iqpe;
+  std::unique_ptr<dd::Package<>>          dd;
+  std::ofstream                           ofs;
+
+  ec::Configuration config{};
+
+  void TearDown() override {}
+  void SetUp() override {
+    precision = GetParam();
+
+    dd = std::make_unique<dd::Package<>>(precision + 1);
+
+    qpe = std::make_unique<qc::QPE>(precision);
+
+    const auto lambda = dynamic_cast<qc::QPE*>(qpe.get())->lambda;
+    iqpe              = std::make_unique<qc::QPE>(lambda, precision, true);
+
+    std::cout << "Estimating lambda = " << lambda << "π up to " << precision
+              << "-bit precision.\n";
+
+    theta = lambda / 2;
+
+    std::cout << "Expected theta=" << theta << "\n";
+    std::bitset<64> binaryExpansion{};
+    dd::fp          expansion = theta * 2;
+    std::size_t     index     = 0;
+    while (std::abs(expansion) > 1e-8) {
+      if (expansion >= 1.) {
+        binaryExpansion.set(index);
+        expansion -= 1.0;
+      }
+      index++;
+      expansion *= 2;
+    }
+
+    expectedResult = 0ULL;
+    for (std::size_t i = 0; i < precision; ++i) {
+      if (binaryExpansion.test(i)) {
+        expectedResult |= (1ULL << (precision - 1 - i));
+      }
+    }
+    std::stringstream ss{};
+    for (auto i = static_cast<int>(precision - 1); i >= 0; --i) {
+      if ((expectedResult & (1ULL << i)) != 0) {
+        ss << 1;
+      } else {
+        ss << 0;
+      }
+    }
+    expectedResultRepresentation = ss.str();
+
+    std::cout << "Theta is exactly representable using " << precision
+              << " bits.\n";
+    std::cout << "The expected output state is |"
+              << expectedResultRepresentation << ">.\n";
+
+    config.optimizations.transformDynamicCircuit        = true;
+    config.optimizations.backpropagateOutputPermutation = true;
+  }
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    Eval, DynamicCircuitTestExactQPE, testing::Range<std::size_t>(1U, 64U, 5U),
+    [](const testing::TestParamInfo<DynamicCircuitTestExactQPE::ParamType>&
+           inf) {
+      const auto        nqubits = inf.param;
+      std::stringstream ss{};
+      ss << nqubits;
+      if (nqubits == 1) {
+        ss << "_qubit";
+      } else {
+        ss << "_qubits";
+      }
+      return ss.str();
+    });
+
+TEST_P(DynamicCircuitTestExactQPE, UnitaryEquivalence) {
+  ec::EquivalenceCheckingManager ecm(*qpe, *iqpe, config);
+  ecm.run();
+  EXPECT_EQ(ecm.equivalence(), ec::EquivalenceCriterion::Equivalent);
+}
+
+class DynamicCircuitTestInexactQPE
+    : public testing::TestWithParam<std::size_t> {
+protected:
+  std::size_t                             precision{};
+  dd::fp                                  theta{};
+  std::size_t                             expectedResult{};
+  std::string                             expectedResultRepresentation{};
+  std::size_t                             secondExpectedResult{};
+  std::string                             secondExpectedResultRepresentation{};
+  std::unique_ptr<qc::QuantumComputation> qpe;
+  std::unique_ptr<qc::QuantumComputation> iqpe;
+  std::unique_ptr<dd::Package<>>          dd;
+  std::ofstream                           ofs;
+
+  ec::Configuration config{};
+
+  void TearDown() override {}
+  void SetUp() override {
+    precision = GetParam();
+
+    dd = std::make_unique<dd::Package<>>(precision + 1);
+
+    qpe = std::make_unique<qc::QPE>(precision, false);
+
+    const auto lambda = dynamic_cast<qc::QPE*>(qpe.get())->lambda;
+    iqpe              = std::make_unique<qc::QPE>(lambda, precision, true);
+
+    std::cout << "Estimating lambda = " << lambda << "π up to " << precision
+              << "-bit precision.\n";
+
+    theta = lambda / 2;
+
+    std::cout << "Expected theta=" << theta << "\n";
+    std::bitset<64> binaryExpansion{};
+    dd::fp          expansion = theta * 2;
+    std::size_t     index     = 0;
+    while (std::abs(expansion) > 1e-8) {
+      if (expansion >= 1.) {
+        binaryExpansion.set(index);
+        expansion -= 1.0;
+      }
+      index++;
+      expansion *= 2;
+    }
+
+    expectedResult = 0ULL;
+    for (std::size_t i = 0; i < precision; ++i) {
+      if (binaryExpansion.test(i)) {
+        expectedResult |= (1ULL << (precision - 1 - i));
+      }
+    }
+    std::stringstream ss{};
+    for (auto i = precision; i > 0; --i) {
+      if ((expectedResult & (1ULL << (i - 1))) != 0) {
+        ss << 1;
+      } else {
+        ss << 0;
+      }
+    }
+    expectedResultRepresentation = ss.str();
+
+    secondExpectedResult = expectedResult + 1;
+    ss.str("");
+    for (auto i = precision; i > 0; --i) {
+      if ((secondExpectedResult & (1ULL << (i - 1))) != 0) {
+        ss << 1;
+      } else {
+        ss << 0;
+      }
+    }
+    secondExpectedResultRepresentation = ss.str();
+
+    std::cout << "Theta is not exactly representable using " << precision
+              << " bits.\n";
+    std::cout << "Most probable output states are |"
+              << expectedResultRepresentation << "> and |"
+              << secondExpectedResultRepresentation << ">.\n";
+
+    config.optimizations.transformDynamicCircuit        = true;
+    config.optimizations.backpropagateOutputPermutation = true;
+  }
+};
+
+INSTANTIATE_TEST_SUITE_P(Eval, DynamicCircuitTestInexactQPE,
+                         testing::Range<std::size_t>(1U, 15U, 3U),
+                         [](const testing::TestParamInfo<
+                             DynamicCircuitTestInexactQPE::ParamType>& inf) {
+                           const auto        nqubits = inf.param;
+                           std::stringstream ss{};
+                           ss << nqubits;
+                           if (nqubits == 1) {
+                             ss << "_qubit";
+                           } else {
+                             ss << "_qubits";
+                           }
+                           return ss.str();
+                         });
+
+TEST_P(DynamicCircuitTestInexactQPE, UnitaryEquivalence) {
+  ec::EquivalenceCheckingManager ecm(*qpe, *iqpe, config);
+  ecm.run();
+  EXPECT_EQ(ecm.equivalence(), ec::EquivalenceCriterion::Equivalent);
+}
+
+class DynamicCircuitTestBV : public testing::TestWithParam<std::size_t> {
+protected:
+  std::size_t                             bitwidth{};
+  std::unique_ptr<qc::QuantumComputation> bv;
+  std::unique_ptr<qc::QuantumComputation> dbv;
+  std::unique_ptr<dd::Package<>>          dd;
+  std::ofstream                           ofs;
+
+  ec::Configuration config{};
+
+  void TearDown() override {}
+  void SetUp() override {
+    bitwidth = GetParam();
+
+    dd = std::make_unique<dd::Package<>>(bitwidth + 1);
+
+    bv = std::make_unique<qc::BernsteinVazirani>(bitwidth);
+
+    const auto s = dynamic_cast<qc::BernsteinVazirani*>(bv.get())->s;
+    dbv          = std::make_unique<qc::BernsteinVazirani>(s, bitwidth, true);
+
+    const auto expected =
+        dynamic_cast<qc::BernsteinVazirani*>(bv.get())->expected;
+    std::cout << "Hidden bitstring: " << expected << " (" << bitwidth
+              << " qubits)\n";
+
+    config.optimizations.transformDynamicCircuit        = true;
+    config.optimizations.backpropagateOutputPermutation = true;
+  }
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    Eval, DynamicCircuitTestBV, testing::Range<std::size_t>(1U, 64U, 5U),
+    [](const testing::TestParamInfo<DynamicCircuitTestBV::ParamType>& inf) {
+      const auto        nqubits = inf.param;
+      std::stringstream ss{};
+      ss << nqubits;
+      if (nqubits == 1) {
+        ss << "_qubit";
+      } else {
+        ss << "_qubits";
+      }
+      return ss.str();
+    });
+
+TEST_P(DynamicCircuitTestBV, UnitaryEquivalence) {
+  ec::EquivalenceCheckingManager ecm(*bv, *dbv, config);
+  ecm.run();
+  EXPECT_EQ(ecm.equivalence(), ec::EquivalenceCriterion::Equivalent);
+}
+
+class DynamicCircuitTestQFT : public testing::TestWithParam<std::size_t> {
+protected:
+  std::size_t                             precision{};
+  std::unique_ptr<qc::QuantumComputation> qft;
+  std::unique_ptr<qc::QuantumComputation> dqft;
+  std::unique_ptr<dd::Package<>>          dd;
+  std::ofstream                           ofs;
+
+  ec::Configuration config{};
+
+  void TearDown() override {}
+  void SetUp() override {
+    precision = GetParam();
+
+    dd = std::make_unique<dd::Package<>>(precision);
+
+    qft = std::make_unique<qc::QFT>(precision);
+
+    dqft = std::make_unique<qc::QFT>(precision, true, true);
+
+    config.optimizations.transformDynamicCircuit        = true;
+    config.optimizations.backpropagateOutputPermutation = true;
+  }
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    Eval, DynamicCircuitTestQFT, testing::Range<std::size_t>(1U, 65U, 5U),
+    [](const testing::TestParamInfo<DynamicCircuitTestQFT::ParamType>& inf) {
+      const auto        nqubits = inf.param;
+      std::stringstream ss{};
+      ss << nqubits;
+      if (nqubits == 1) {
+        ss << "_qubit";
+      } else {
+        ss << "_qubits";
+      }
+      return ss.str();
+    });
+
+TEST_P(DynamicCircuitTestQFT, UnitaryEquivalence) {
+  ec::EquivalenceCheckingManager ecm(*qft, *dqft, config);
+  ecm.run();
+  EXPECT_EQ(ecm.equivalence(), ec::EquivalenceCriterion::Equivalent);
+}

--- a/test/test_simple_circuit_identities.cpp
+++ b/test/test_simple_circuit_identities.cpp
@@ -180,3 +180,10 @@ TEST_P(SimpleCircuitIdentitiesTest, ReconstructSWAPs) {
 
   EXPECT_TRUE(ecm->getResults().consideredEquivalent());
 }
+
+TEST_P(SimpleCircuitIdentitiesTest, BackpropagateOutputPermutation) {
+  ecm->backpropagateOutputPermutation();
+  EXPECT_NO_THROW(ecm->run(););
+
+  EXPECT_TRUE(ecm->getResults().consideredEquivalent());
+}


### PR DESCRIPTION
## Description

This PR adds a new option to QCEC that allows to backpropagate the output permutation derived from the measurements of a circuit to the initial layout based on the optimization pass added in cda-tum/mqt-core#512.

This is especially helpful for verifying dynamic quantum circuits because it is rather hard (if not impossible) to define a proper initial layout for the circuit after it has been transformed to a regular quantum circuit by substituting resets and deferring measurements without an educated guess.

The new option is opt-in for now and can be activated by passing `backpropagate_output_permutation=True` as a keyword argument to the `verify` methods or by setting `config.optimizations.backpropagate_output_permutation=True` on a respective `Configuration` object.

Fixes #343 

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
