### PR TITLE
🚸🚨 Eliminate reference members and improve `TaskManager` interface

### DIFF
--- a/include/checker/dd/DDEquivalenceChecker.hpp
+++ b/include/checker/dd/DDEquivalenceChecker.hpp
@@ -24,8 +24,8 @@ public:
                        Configuration                 config)
       : EquivalenceChecker(circ1, circ2, std::move(config)),
         dd(std::make_unique<dd::Package<Config>>(nqubits)),
-        taskManager1(TaskManager<DDType, Config>(circ1, dd)),
-        taskManager2(TaskManager<DDType, Config>(circ2, dd)) {}
+        taskManager1(TaskManager<DDType, Config>(circ1, *dd)),
+        taskManager2(TaskManager<DDType, Config>(circ2, *dd)) {}
 
   EquivalenceCriterion run() override;
 

--- a/include/checker/dd/TaskManager.hpp
+++ b/include/checker/dd/TaskManager.hpp
@@ -15,13 +15,12 @@ template <class DDType, class Config = dd::DDPackageConfig> class TaskManager {
   using DDPackage = typename dd::Package<Config>;
 
 public:
-  TaskManager(const qc::QuantumComputation& circ,
-              std::unique_ptr<DDPackage>& dd, const ec::Direction& dir) noexcept
-      : qc(&circ), package(dd.get()), direction(dir),
+  TaskManager(const qc::QuantumComputation& circ, DDPackage& dd,
+              const ec::Direction& dir) noexcept
+      : qc(&circ), package(&dd), direction(dir),
         permutation(circ.initialLayout), iterator(circ.begin()),
         end(circ.end()) {}
-  TaskManager(const qc::QuantumComputation& circ,
-              std::unique_ptr<DDPackage>&   dd) noexcept
+  TaskManager(const qc::QuantumComputation& circ, DDPackage& dd) noexcept
       : TaskManager(circ, dd, Direction::Left) {}
 
   [[nodiscard]] bool finished() const noexcept { return iterator == end; }

--- a/include/checker/dd/TaskManager.hpp
+++ b/include/checker/dd/TaskManager.hpp
@@ -17,8 +17,9 @@ template <class DDType, class Config = dd::DDPackageConfig> class TaskManager {
 public:
   TaskManager(const qc::QuantumComputation& circ,
               std::unique_ptr<DDPackage>& dd, const ec::Direction& dir) noexcept
-      : qc(&circ), package(dd), direction(dir), permutation(circ.initialLayout),
-        iterator(circ.begin()), end(circ.end()) {}
+      : qc(&circ), package(dd.get()), direction(dir),
+        permutation(circ.initialLayout), iterator(circ.begin()),
+        end(circ.end()) {}
   TaskManager(const qc::QuantumComputation& circ,
               std::unique_ptr<DDPackage>&   dd) noexcept
       : TaskManager(circ, dd, Direction::Left) {}
@@ -126,7 +127,7 @@ public:
 
 private:
   const qc::QuantumComputation* qc{};
-  std::unique_ptr<DDPackage>&   package;
+  DDPackage*                    package;
   ec::Direction                 direction = Direction::Left;
   qc::Permutation               permutation{};
   decltype(qc->begin())         iterator;

--- a/include/checker/dd/applicationscheme/ApplicationScheme.hpp
+++ b/include/checker/dd/applicationscheme/ApplicationScheme.hpp
@@ -92,7 +92,7 @@ protected:
 
 public:
   ApplicationScheme(TM& tm1, TM& tm2) noexcept
-      : taskManager1(tm1), taskManager2(tm2){};
+      : taskManager1(&tm1), taskManager2(&tm2){};
 
   virtual ~ApplicationScheme() = default;
 
@@ -100,8 +100,8 @@ public:
   virtual std::pair<std::size_t, std::size_t> operator()() = 0;
 
 protected:
-  TM& taskManager1;
-  TM& taskManager2;
+  TM* taskManager1;
+  TM* taskManager2;
 };
 
 } // namespace ec

--- a/include/checker/dd/applicationscheme/GateCostApplicationScheme.hpp
+++ b/include/checker/dd/applicationscheme/GateCostApplicationScheme.hpp
@@ -56,7 +56,7 @@ public:
       return {1U, 1U};
     }
 
-    const auto& op = this->taskManager1();
+    const auto& op = (*this->taskManager1)();
     const auto  key =
         GateCostLookupTableKeyType{op->getType(), op->getNcontrols()};
     std::size_t cost = 1U;

--- a/include/checker/dd/applicationscheme/LookaheadApplicationScheme.hpp
+++ b/include/checker/dd/applicationscheme/LookaheadApplicationScheme.hpp
@@ -50,13 +50,13 @@ public:
 
     // greedily chose the smaller resulting decision diagram
     if (const auto size2 = dd2.size(); size1 <= size2) {
-      assert(!this->taskManager1.finished());
+      assert(!this->taskManager1->finished());
       *internalState = dd1;
       package->decRef(op1);
       cached1 = false;
       this->taskManager1->advanceIterator();
     } else {
-      assert(!this->taskManager2.finished());
+      assert(!this->taskManager2->finished());
       *internalState = dd2;
       package->decRef(op2);
       cached2 = false;

--- a/include/checker/dd/applicationscheme/LookaheadApplicationScheme.hpp
+++ b/include/checker/dd/applicationscheme/LookaheadApplicationScheme.hpp
@@ -30,14 +30,14 @@ public:
 
     if (!cached1) {
       // cache the current operation
-      op1 = this->taskManager1.getDD();
+      op1 = this->taskManager1->getDD();
       package->incRef(op1);
       cached1 = true;
     }
 
     if (!cached2) {
       // cache the current operation
-      op2 = this->taskManager2.getInverseDD();
+      op2 = this->taskManager2->getInverseDD();
       package->incRef(op2);
       cached2 = true;
     }
@@ -54,13 +54,13 @@ public:
       *internalState = dd1;
       package->decRef(op1);
       cached1 = false;
-      this->taskManager1.advanceIterator();
+      this->taskManager1->advanceIterator();
     } else {
       assert(!this->taskManager2.finished());
       *internalState = dd2;
       package->decRef(op2);
       cached2 = false;
-      this->taskManager2.advanceIterator();
+      this->taskManager2->advanceIterator();
     }
 
     // properly track reference counts

--- a/include/checker/dd/applicationscheme/ProportionalApplicationScheme.hpp
+++ b/include/checker/dd/applicationscheme/ProportionalApplicationScheme.hpp
@@ -23,8 +23,8 @@ public:
 
 private:
   [[nodiscard]] std::size_t computeGateRatio() const noexcept {
-    const std::size_t size1 = this->taskManager1.getCircuit()->size();
-    const std::size_t size2 = this->taskManager2.getCircuit()->size();
+    const std::size_t size1 = this->taskManager1->getCircuit()->size();
+    const std::size_t size2 = this->taskManager2->getCircuit()->size();
     if (size1 == 0U) {
       return size2;
     }

--- a/test/test_gate_cost_application_scheme.cpp
+++ b/test/test_gate_cost_application_scheme.cpp
@@ -37,7 +37,7 @@ TEST_F(GateCostApplicationSchemeTest, SchemeFromProfile) {
   // apply Toffoli gate
   qc.mcx({1_pc, 2_pc}, 0);
 
-  auto tm = ec::TaskManager<qc::MatrixDD>(qc, dd);
+  auto tm = ec::TaskManager<qc::MatrixDD>(qc, *dd);
 
   auto scheme = ec::GateCostApplicationScheme(tm, tm, filename);
 
@@ -52,13 +52,13 @@ TEST_F(GateCostApplicationSchemeTest, SchemeFromProfile) {
   ec::EquivalenceCheckingManager ecm(qc, qc, config);
   ecm.run();
   EXPECT_TRUE(ecm.getResults().consideredEquivalent());
-  std::cout << ecm.toString() << std::endl;
+  std::cout << ecm.toString() << "\n";
 }
 
 TEST_F(GateCostApplicationSchemeTest, iSWAP) {
   qc.iswap(0, 1);
 
-  auto tm = ec::TaskManager<qc::MatrixDD>(qc, dd);
+  auto tm = ec::TaskManager<qc::MatrixDD>(qc, *dd);
 
   auto scheme = ec::GateCostApplicationScheme(tm, tm, &ec::legacyCostFunction);
 
@@ -73,7 +73,7 @@ TEST_F(GateCostApplicationSchemeTest, Peres) {
 
   qc.cperes(0_pc, 1, 2);
 
-  auto tm = ec::TaskManager<qc::MatrixDD>(qc, dd);
+  auto tm = ec::TaskManager<qc::MatrixDD>(qc, *dd);
 
   auto scheme = ec::GateCostApplicationScheme(tm, tm, &ec::legacyCostFunction);
 


### PR DESCRIPTION
## Description

This was triggered by a clang-tidy warning that popped up in #348.
This PR also adjusts the `TaskManager` interface to take a reference to a package instance instead of a unique pointer; making the interface more generic.
This should unblock #348.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
