### PR TITLE
⬆️  update `mqt-core`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,9 @@ endmacro()
 
 check_submodule_present(mqt-core)
 
+option(BUILD_MQT_QCEC_TESTS "Also build tests for the MQT QCEC project" ON)
 option(BUILD_MQT_QCEC_BINDINGS "Build the MQT QCEC Python bindings" OFF)
+
 if(BUILD_MQT_QCEC_BINDINGS)
   # ensure that the BINDINGS option is set
   set(BINDINGS
@@ -42,11 +44,12 @@ if(BUILD_MQT_QCEC_BINDINGS)
     OPTIONAL_COMPONENTS Development.SABIModule)
 endif()
 
+include(cmake/ExternalDependencies.cmake)
+
 # add main library code
 add_subdirectory(src)
 
 # add test code
-option(BUILD_MQT_QCEC_TESTS "Also build tests for the MQT QCEC project" ON)
 if(BUILD_MQT_QCEC_TESTS)
   enable_testing()
   include(GoogleTest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # set required cmake version
-cmake_minimum_required(VERSION 3.19...3.27)
+cmake_minimum_required(VERSION 3.19...3.28)
 
 project(
   qcec

--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -1,0 +1,83 @@
+# Declare all external dependencies and make sure that they are available.
+
+include(FetchContent)
+set(FETCH_PACKAGES "")
+
+# A macro to declare a dependency that takes into account the different CMake
+# versions and the features that they make available. In particular: - CMake
+# 3.24 introduced the `FIND_PACKAGE_ARGS` option to `FetchContent` which allows
+# to combine `FetchContent_Declare` and `find_package` in a single call. - CMake
+# 3.25 introduced the `SYSTEM` option to `FetchContent_Declare` which marks the
+# dependency as a system dependency. This is useful to avoid compiler warnings
+# from external header only libraries. - CMake 3.28 introduced the
+# `EXCLUDE_FROM_ALL` option to `FetchContent_Declare` which allows to exclude
+# all targets from the dependency from the `all` target.
+macro(DECLARE_DEPENDENCY)
+  cmake_parse_arguments(DEPENDENCY "SYSTEM;EXCLUDE_FROM_ALL"
+                        "NAME;URL;MD5;MIN_VERSION;ALT_NAME" "" ${ARGN})
+  set(ADDITIONAL_OPTIONS "")
+  if(DEPENDENCY_SYSTEM AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.25)
+    list(APPEND ADDITIONAL_OPTIONS SYSTEM)
+  endif()
+  if(DEPENDENCY_EXCLUDE_FROM_ALL AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.28)
+    list(APPEND ADDITIONAL_OPTIONS EXCLUDE_FROM_ALL)
+  endif()
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.28)
+    FetchContent_Declare(
+      ${DEPENDENCY_NAME}
+      URL ${DEPENDENCY_URL}
+      URL_MD5 ${DEPENDENCY_MD5}
+      ${ADDITIONAL_OPTIONS} FIND_PACKAGE_ARGS ${DEPENDENCY_MIN_VERSION} NAMES
+      ${DEPENDENCY_ALT_NAME})
+    list(APPEND FETCH_PACKAGES ${DEPENDENCY_NAME})
+  elseif(CMAKE_VERSION VERSION_GREATER_EQUAL 3.25)
+    FetchContent_Declare(
+      ${DEPENDENCY_NAME}
+      URL ${DEPENDENCY_URL}
+      URL_MD5 ${DEPENDENCY_MD5}
+      ${ADDITIONAL_OPTIONS} FIND_PACKAGE_ARGS ${DEPENDENCY_MIN_VERSION} NAMES
+      ${DEPENDENCY_ALT_NAME})
+    list(APPEND FETCH_PACKAGES ${DEPENDENCY_NAME})
+  elseif(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
+    FetchContent_Declare(
+      ${DEPENDENCY_NAME}
+      URL ${DEPENDENCY_URL}
+      URL_MD5 ${DEPENDENCY_MD5}
+      ${ADDITIONAL_OPTIONS} FIND_PACKAGE_ARGS ${DEPENDENCY_MIN_VERSION} NAMES
+      ${DEPENDENCY_ALT_NAME})
+    list(APPEND FETCH_PACKAGES ${DEPENDENCY_NAME})
+  else()
+    # try to get the system installed version
+    find_package(${DEPENDENCY_NAME} ${DEPENDENCY_MIN_VERSION} QUIET NAMES
+                 ${DEPENDENCY_ALT_NAME})
+    if(NOT ${DEPENDENCY_NAME}_FOUND)
+      FetchContent_Declare(
+        ${DEPENDENCY_NAME}
+        URL ${DEPENDENCY_URL}
+        URL_MD5 ${DEPENDENCY_MD5})
+      list(APPEND FETCH_PACKAGES ${DEPENDENCY_NAME})
+    endif()
+  endif()
+endmacro()
+
+if(BUILD_MQT_QCEC_TESTS)
+  set(gtest_force_shared_crt # cmake-lint: disable=C0103
+      ON
+      CACHE BOOL "" FORCE)
+  declare_dependency(
+    NAME
+    googletest
+    URL
+    https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz
+    MD5
+    c8340a482851ef6a3fe618a082304cfc
+    MIN_VERSION
+    1.14.0
+    ALT_NAME
+    GTest
+    SYSTEM
+    EXCLUDE_FROM_ALL)
+endif()
+
+# Make all declared dependencies available.
+FetchContent_MakeAvailable(${FETCH_PACKAGES})

--- a/include/checker/dd/TaskManager.hpp
+++ b/include/checker/dd/TaskManager.hpp
@@ -40,10 +40,10 @@ public:
   }
 
   [[nodiscard]] qc::MatrixDD getDD() {
-    return dd::getDD((*iterator).get(), package, permutation);
+    return dd::getDD((*iterator).get(), *package, permutation);
   }
   [[nodiscard]] qc::MatrixDD getInverseDD() {
-    return dd::getInverseDD((*iterator).get(), package, permutation);
+    return dd::getInverseDD((*iterator).get(), *package, permutation);
   }
 
   [[nodiscard]] const qc::QuantumComputation* getCircuit() const noexcept {
@@ -95,7 +95,7 @@ public:
   void finish() { finish(internalState); }
 
   void changePermutation(DDType& state) {
-    dd::changePermutation(state, permutation, qc->outputPermutation, package,
+    dd::changePermutation(state, permutation, qc->outputPermutation, *package,
                           static_cast<bool>(direction));
   }
   void changePermutation() { changePermutation(internalState); }

--- a/include/checker/dd/simulation/StateGenerator.hpp
+++ b/include/checker/dd/simulation/StateGenerator.hpp
@@ -22,12 +22,11 @@ public:
   }
   StateGenerator() : StateGenerator(0U) {}
 
-  template <class DDPackage = dd::Package<>>
+  template <class Config = dd::DDPackageConfig>
   qc::VectorDD
-  generateRandomState(std::unique_ptr<DDPackage>& dd,
-                      const std::size_t           totalQubits,
-                      const std::size_t           ancillaryQubits = 0U,
-                      const StateType type = StateType::ComputationalBasis) {
+  generateRandomState(dd::Package<Config>& dd, const std::size_t totalQubits,
+                      const std::size_t ancillaryQubits = 0U,
+                      const StateType   type = StateType::ComputationalBasis) {
     switch (type) {
     case ec::StateType::Random1QBasis:
       return generateRandom1QBasisState(dd, totalQubits, ancillaryQubits);
@@ -39,9 +38,9 @@ public:
     }
   }
 
-  template <class DDPackage = dd::Package<>>
+  template <class Config = dd::DDPackageConfig>
   qc::VectorDD generateRandomComputationalBasisState(
-      std::unique_ptr<DDPackage>& dd, const std::size_t totalQubits,
+      dd::Package<Config>& dd, const std::size_t totalQubits,
       const std::size_t ancillaryQubits = 0U) {
     // determine how many qubits truly are random
     const std::size_t randomQubits = totalQubits - ancillaryQubits;
@@ -87,14 +86,14 @@ public:
     }
 
     // return the appropriate decision diagram
-    return dd->makeBasisState(totalQubits, stimulusBits);
+    return dd.makeBasisState(totalQubits, stimulusBits);
   }
 
-  template <class DDPackage = dd::Package<>>
+  template <class Config = dd::DDPackageConfig>
   qc::VectorDD
-  generateRandom1QBasisState(std::unique_ptr<DDPackage>& dd,
-                             const std::size_t           totalQubits,
-                             const std::size_t           ancillaryQubits = 0U) {
+  generateRandom1QBasisState(dd::Package<Config>& dd,
+                             const std::size_t    totalQubits,
+                             const std::size_t    ancillaryQubits = 0U) {
     // determine how many qubits truly are random
     const std::size_t randomQubits = totalQubits - ancillaryQubits;
 
@@ -127,14 +126,14 @@ public:
     }
 
     // return the appropriate decision diagram
-    return dd->makeBasisState(totalQubits, randomBasisState);
+    return dd.makeBasisState(totalQubits, randomBasisState);
   }
 
-  template <class DDPackage = dd::Package<>>
+  template <class Config = dd::DDPackageConfig>
   qc::VectorDD
-  generateRandomStabilizerState(std::unique_ptr<DDPackage>& dd,
-                                const std::size_t           totalQubits,
-                                const std::size_t ancillaryQubits = 0U) {
+  generateRandomStabilizerState(dd::Package<Config>& dd,
+                                const std::size_t    totalQubits,
+                                const std::size_t    ancillaryQubits = 0U) {
     // determine how many qubits truly are random
     const std::size_t randomQubits = totalQubits - ancillaryQubits;
 
@@ -145,16 +144,16 @@ public:
 
     // generate the associated stabilizer state by simulating the Clifford
     // circuit
-    auto stabilizer = simulate(&rcs, dd->makeZeroState(randomQubits), dd);
+    auto stabilizer = simulate(&rcs, dd.makeZeroState(randomQubits), dd);
 
     // decrease the ref count right after so that it stays correct later on
-    dd->decRef(stabilizer);
+    dd.decRef(stabilizer);
 
     // add |0> edges for all the ancillary qubits
     auto initial = stabilizer;
     for (std::size_t p = randomQubits; p < totalQubits; ++p) {
-      initial = dd->makeDDNode(static_cast<dd::Qubit>(p),
-                               std::array{initial, qc::VectorDD::zero()});
+      initial = dd.makeDDNode(static_cast<dd::Qubit>(p),
+                              std::array{initial, qc::VectorDD::zero()});
     }
 
     // return the resulting decision diagram

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,14 +98,6 @@ sdist.exclude = [
     "**/plots",
     "**/test",
     "**/tests",
-    "extern/mqt-core/extern/json/include",
-    "extern/mqt-core/extern/googletest",
-    "extern/mqt-core/extern/boost/config/checks",
-    "extern/mqt-core/extern/boost/config/tools",
-    "extern/mqt-core/extern/boost/multiprecision/config",
-    "extern/mqt-core/extern/boost/multiprecision/example",
-    "extern/mqt-core/extern/boost/multiprecision/performance",
-    "extern/mqt-core/extern/boost/multiprecision/tools"
 ]
 
 [tool.scikit-build.cmake.define]

--- a/src/checker/dd/DDSimulationChecker.cpp
+++ b/src/checker/dd/DDSimulationChecker.cpp
@@ -35,7 +35,7 @@ void DDSimulationChecker::setRandomInitialState(StateGenerator& generator) {
   const auto stateType  = configuration.simulation.stateType;
 
   initialState =
-      generator.generateRandomState(dd, nqubits, nancillary, stateType);
+      generator.generateRandomState(*dd, nqubits, nancillary, stateType);
 }
 
 } // namespace ec

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,12 +1,3 @@
-if(NOT TARGET gtest OR NOT TARGET gmock)
-  # Prevent overriding the parent project's compiler/linker settings on Windows
-  set(gtest_force_shared_crt # cmake-lint: disable=C0103
-      ON
-      CACHE BOOL "" FORCE)
-  add_subdirectory("${PROJECT_SOURCE_DIR}/extern/mqt-core/extern/googletest"
-                   "extern/mqt-core/extern/googletest" EXCLUDE_FROM_ALL)
-endif()
-
 package_add_test(
   ${PROJECT_NAME}_test
   ${PROJECT_NAME}

--- a/test/test_simple_circuit_identities.cpp
+++ b/test/test_simple_circuit_identities.cpp
@@ -24,9 +24,9 @@ protected:
   void SetUp() override {
     const auto [circ1, circ2] = GetParam().second;
     std::stringstream ss1{circ1};
-    qcOriginal.import(ss1, qc::Format::OpenQASM);
+    qcOriginal.import(ss1, qc::Format::OpenQASM2);
     std::stringstream ss2{circ2};
-    qcAlternative.import(ss2, qc::Format::OpenQASM);
+    qcAlternative.import(ss2, qc::Format::OpenQASM2);
 
     config.optimizations.reconstructSWAPs     = false;
     config.optimizations.fuseSingleQubitGates = false;

--- a/test/test_zx.cpp
+++ b/test/test_zx.cpp
@@ -65,11 +65,11 @@ TEST_F(ZXTest, NonEquivalent) {
   qcOriginal.import(
       std::stringstream("OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg "
                         "q[2];\ncx q[0], q[1];\n"),
-      qc::Format::OpenQASM);
+      qc::Format::OpenQASM2);
   qcAlternative.import(
       std::stringstream("OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[2];\nh "
                         "q[0]; cx q[1], q[0]; h q[0]; h q[1];\n"),
-      qc::Format::OpenQASM);
+      qc::Format::OpenQASM2);
   ecm = std::make_unique<ec::EquivalenceCheckingManager>(qcOriginal,
                                                          qcAlternative, config);
 


### PR DESCRIPTION
## Description

This PR was triggered by the failures in #349 and its purpose is to better isolate the changes into separate PRs.
- cda-tum/mqt-core#515

has dropped the submodules in `mqt-core` and replaced them with `FetchContent`. As such, the `googletest` test dependency is no longer available at its typical location.
Consequently, this PR now also uses `FetchContent` to get `googletest`.
In a future PR, this will most likely be extended to the `mqt-core` submodule as well.

This should unblock #349.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
