### PR TITLE
🚨 fix Qiskit 0.46.0 deprecation warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,9 @@ filterwarnings = [
     'ignore:.*Building a flow controller with keyword arguments is going to be deprecated*:PendingDeprecationWarning:qiskit',
     'ignore:.*encountered in det.*:RuntimeWarning:numpy.linalg:',
     'ignore:.*datetime\.datetime\.utcfromtimestamp.*:DeprecationWarning:',
+    'ignore:.*qiskit.utils.parallel*:DeprecationWarning:qiskit',
+    'ignore:.*qiskit.tools.events*:DeprecationWarning:qiskit',
+    'ignore:.*qiskit.qasm*:DeprecationWarning:qiskit',
 ]
 
 [tool.coverage]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ requires-python = ">=3.8"
 dependencies = [
     "importlib_resources>=5.0; python_version < '3.10'",
     "typing_extensions>=4.2",
-    "qiskit-terra>=0.22.1",
+    "qiskit[qasm3-import]>=0.45.0",
 ]
 dynamic = ["version"]
 
@@ -57,7 +57,7 @@ docs = [
     "nbsphinx",
     "sphinxext-opengraph",
     "sphinx-autodoc-typehints",
-    "qiskit-terra[visualization]",
+    "qiskit[visualization]",
 ]
 dev = ["mqt.qcec[coverage, docs]"]
 

--- a/test/python/constraints.txt
+++ b/test/python/constraints.txt
@@ -4,4 +4,4 @@ pybind11==2.11.0
 pytest==7.0.0
 importlib_resources==5.0.0
 typing_extensions==4.2.0
-qiskit-terra==0.22.1
+qiskit==0.45.0

--- a/test/python/test_construction.py
+++ b/test/python/test_construction.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from qiskit import QuantumCircuit
+from qiskit import QuantumCircuit, qasm2
 
 from mqt import qcec
 
@@ -32,6 +32,6 @@ def test_constructor_with_configuration(example_circuit: QuantumCircuit) -> None
 def test_default_constructor_with_file(example_circuit: QuantumCircuit) -> None:
     """Test constructing an instance from two circuit files with all default arguments."""
     filename = "test.qasm"
-    example_circuit.qasm(filename=filename)
+    qasm2.dump(example_circuit, Path(filename))
     qcec.EquivalenceCheckingManager(circ1=filename, circ2=filename)
     Path(filename).unlink()

--- a/test/python/test_symbolic.py
+++ b/test/python/test_symbolic.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import pytest
 from qiskit import QuantumCircuit, transpile
 from qiskit.circuit import Parameter
-from qiskit.providers.fake_provider import FakeAthens
 
 from mqt import qcec
 from mqt.qcec.compilation_flow_profiles import AncillaMode
@@ -186,7 +185,12 @@ def test_cnot_rx_non_equ_approx(cnot_rx: QuantumCircuit, cnot_rx_flipped_approx:
 @pytest.mark.parametrize("optimization_level", [0, 1, 2, 3])
 def test_verify_compilation_on_optimization_levels(original_circuit: QuantumCircuit, optimization_level: int) -> None:
     """Test the verification of the compilation of a circuit to the 5-qubit IBMQ Athens architecture with various optimization levels."""
-    compiled_circuit = transpile(original_circuit, backend=FakeAthens(), optimization_level=optimization_level)
+    compiled_circuit = transpile(
+        original_circuit,
+        coupling_map=[[0, 1], [1, 0], [1, 2], [2, 1], [2, 3], [3, 2], [3, 4], [4, 3]],
+        basis_gates=["cx", "x", "id", "u3", "measure", "u2", "rz", "u1", "reset", "sx"],
+        optimization_level=optimization_level,
+    )
     result = qcec.verify_compilation(original_circuit, compiled_circuit, optimization_level, timeout=3600)
     assert result.equivalence in {
         qcec.EquivalenceCriterion.equivalent,
@@ -201,7 +205,12 @@ def test_verify_compilation_on_optimization_levels_config(
     """Test the verification of the compilation of a circuit to the 5-qubit IBMQ Athens architecture with various optimization levels."""
     config = qcec.Configuration()
     config.execution.run_zx_checker = False
-    compiled_circuit = transpile(original_circuit, backend=FakeAthens(), optimization_level=optimization_level)
+    compiled_circuit = transpile(
+        original_circuit,
+        coupling_map=[[0, 1], [1, 0], [1, 2], [2, 1], [2, 3], [3, 2], [3, 4], [4, 3]],
+        basis_gates=["cx", "x", "id", "u3", "measure", "u2", "rz", "u1", "reset", "sx"],
+        optimization_level=optimization_level,
+    )
     result = qcec.verify_compilation(
         original_circuit, compiled_circuit, optimization_level, AncillaMode.NO_ANCILLA, config
     )

--- a/test/python/test_verify.py
+++ b/test/python/test_verify.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import pytest
 from qiskit import QuantumCircuit, transpile
-from qiskit.providers.fake_provider import FakeAthens
 
 from mqt import qcec
 
@@ -70,7 +69,11 @@ def test_compiled_circuit_without_measurements() -> None:
     """
     qc = QuantumCircuit(1)
     qc.x(0)
-    qc_compiled = transpile(qc, backend=FakeAthens())
+    qc_compiled = transpile(
+        qc,
+        coupling_map=[[0, 1], [1, 0], [1, 2], [2, 1], [2, 3], [3, 2], [3, 4], [4, 3]],
+        basis_gates=["cx", "x", "id", "u3", "measure", "u2", "rz", "u1", "reset", "sx"],
+    )
 
     result = qcec.verify(qc, qc_compiled)
     assert result.equivalence == qcec.EquivalenceCriterion.equivalent

--- a/test/python/test_verify_compilation.py
+++ b/test/python/test_verify_compilation.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import pytest
 from qiskit import QuantumCircuit, transpile
-from qiskit.providers.fake_provider import FakeAthens
 
 from mqt import qcec
 
@@ -23,7 +22,12 @@ def original_circuit() -> QuantumCircuit:
 @pytest.mark.parametrize("optimization_level", [0, 1, 2, 3])
 def test_verify_compilation_on_optimization_levels(original_circuit: QuantumCircuit, optimization_level: int) -> None:
     """Test the verification of the compilation of a circuit to the 5-qubit IBMQ Athens architecture with various optimization levels."""
-    compiled_circuit = transpile(original_circuit, backend=FakeAthens(), optimization_level=optimization_level)
+    compiled_circuit = transpile(
+        original_circuit,
+        coupling_map=[[0, 1], [1, 0], [1, 2], [2, 1], [2, 3], [3, 2], [3, 4], [4, 3]],
+        basis_gates=["cx", "x", "id", "u3", "measure", "u2", "rz", "u1", "reset", "sx"],
+        optimization_level=optimization_level,
+    )
     result = qcec.verify_compilation(original_circuit, compiled_circuit, optimization_level=optimization_level)
     assert result.equivalence in {
         qcec.EquivalenceCriterion.equivalent,


### PR DESCRIPTION
## Description

This PR works around some newly introduced deprecation warnings in the latest Qiskit version.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
