### PR TITLE
✨ Support for Qiskit 1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ requires-python = ">=3.8"
 dependencies = [
     "importlib_resources>=5.0; python_version < '3.10'",
     "typing_extensions>=4.2",
-    "qiskit[qasm3-import]>=0.45.0",
+    "qiskit[qasm3-import]>=1.0.0",
 ]
 dynamic = ["version"]
 
@@ -125,14 +125,8 @@ log_cli_level = "INFO"
 xfail_strict = true
 filterwarnings = [
     "error",
-    'ignore:.*qiskit.__qiskit_version__.*:DeprecationWarning:qiskit:',
-    'ignore:.*qiskit.utils.algorithm_globals.QiskitAlgorithmGlobals*:DeprecationWarning:qiskit',
-    'ignore:.*Building a flow controller with keyword arguments is going to be deprecated*:PendingDeprecationWarning:qiskit',
     'ignore:.*encountered in det.*:RuntimeWarning:numpy.linalg:',
     'ignore:.*datetime\.datetime\.utcfromtimestamp.*:DeprecationWarning:',
-    'ignore:.*qiskit.utils.parallel*:DeprecationWarning:qiskit',
-    'ignore:.*qiskit.tools.events*:DeprecationWarning:qiskit',
-    'ignore:.*qiskit.qasm*:DeprecationWarning:qiskit',
 ]
 
 [tool.coverage]

--- a/test/python/constraints.txt
+++ b/test/python/constraints.txt
@@ -4,4 +4,4 @@ pybind11==2.11.0
 pytest==7.0.0
 importlib_resources==5.0.0
 typing_extensions==4.2.0
-qiskit==0.45.0
+qiskit==1.0.0


### PR DESCRIPTION
## Description

This PR marks the official support of Qiskit 1.0 in QCEC.

In order to avoid all kinds of ugly compatibility hacks, this PR also changes the minimum required Qiskit version to 1.0.
Since Qiskit has devoted themselves to following semantic versioning from now on out, this hopefully means fewer compatibility changes in the future.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
