### PR TITLE
🩹 reduce timeouts for ZX timeout tests

### DIFF
--- a/test/test_symbolic.cpp
+++ b/test/test_symbolic.cpp
@@ -60,7 +60,7 @@ TEST_F(SymbolicTest, Timeout) {
     symQc2.rx(xMonom, 0);
   }
   ec::Configuration config{};
-  config.execution.timeout = 1;
+  config.execution.timeout = 0.1;
   auto ecm = ec::EquivalenceCheckingManager(symQc1, symQc2, config);
 
   ecm.run();

--- a/test/test_zx.cpp
+++ b/test/test_zx.cpp
@@ -92,7 +92,7 @@ TEST_F(ZXTest, Timeout) {
     qcAlternative.h(0);
   }
 
-  config.execution.timeout = 1;
+  config.execution.timeout = 0.1;
   ecm = std::make_unique<ec::EquivalenceCheckingManager>(qcOriginal,
                                                          qcAlternative, config);
 


### PR DESCRIPTION
## Description

The new Apple Silicon runners from GitHub are just too fast for our timeout tests 🤯 
This PR reduces the timeouts in the ZX checker tests so that they should work even on significantly faster systems.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
