### PR TITLE
✨ Stripping DDs of their identity

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,6 +7,7 @@ Checks: |
   boost-*,
   bugprone-*,
   -bugprone-easily-swappable-parameters,
+  -bugprone-unchecked-optional-access,
   clang-analyzer-*,
   cppcoreguidelines-*,
   -cppcoreguidelines-non-private-member-variables-in-classes,

--- a/include/checker/dd/DDConstructionChecker.hpp
+++ b/include/checker/dd/DDConstructionChecker.hpp
@@ -31,7 +31,7 @@ private:
   void initializeTask(TaskManager<qc::MatrixDD, ConstructionDDPackageConfig>&
                           taskManager) override {
     DDEquivalenceChecker::initializeTask(taskManager);
-    const auto initial = dd->makeIdent(nqubits);
+    const auto initial = dd->makeIdent();
     taskManager.setInternalState(initial);
     taskManager.incRef();
     taskManager.reduceAncillae();

--- a/src/checker/dd/DDAlternatingChecker.cpp
+++ b/src/checker/dd/DDAlternatingChecker.cpp
@@ -9,7 +9,7 @@ namespace ec {
 void DDAlternatingChecker::initialize() {
   DDEquivalenceChecker::initialize();
   // create the full identity matrix
-  functionality = dd->makeIdent(nqubits);
+  functionality = dd->makeIdent();
   dd->incRef(functionality);
 
   // Only count ancillaries that are present in but not acted upon in both of
@@ -50,7 +50,7 @@ void DDAlternatingChecker::execute() {
 
       // whenever the current functionality resembles the identity, identical
       // gates on both sides cancel
-      if (functionality.p->isIdentity() &&
+      if (functionality.isIdentity() &&
           (configuration.application.alternatingScheme !=
            ApplicationSchemeType::Lookahead) &&
           gatesAreIdentical()) {

--- a/test/test_equality.cpp
+++ b/test/test_equality.cpp
@@ -168,6 +168,7 @@ TEST_F(EqualityTest, AutomaticSwitchToConstructionChecker) {
   // setup default configuration
   config = ec::Configuration{};
   ec::EquivalenceCheckingManager ecm(qc1, qc2, config);
+  ecm.setCheckPartialEquivalence(true);
 
   // this should notice that the alternating checker is not capable of running
   // the circuit and should switch to the construction checker
@@ -180,7 +181,6 @@ TEST_F(EqualityTest, AutomaticSwitchToConstructionChecker) {
 
   // both circuits should be partially equivalent since their action only
   // differs on an ancillary and garbage qubit
-  ecm.setCheckPartialEquivalence(true);
   const auto result = ecm.equivalence();
   EXPECT_EQ(result, ec::EquivalenceCriterion::Equivalent);
 

--- a/test/test_partial_equivalence.cpp
+++ b/test/test_partial_equivalence.cpp
@@ -25,9 +25,9 @@ const std::vector<std::vector<OpType>> PRE_GENERATED_CIRCUITS_SIZE_2_2{
     {Z}, {Tdg}, {S}, {Sdg}, {X, Z}, {Z, X}};
 
 void addPreGeneratedCircuits(QuantumComputation& circuit1,
-                             QuantumComputation& circuit2, const size_t n,
-                             const qc::Qubit groupBeginIndex,
-                             const qc::Qubit groupSize) {
+                             QuantumComputation& circuit2,
+                             const qc::Qubit     groupBeginIndex,
+                             const qc::Qubit     groupSize) {
   const auto& circuits1       = groupSize == 1 ? PRE_GENERATED_CIRCUITS_SIZE_1_1
                                                : PRE_GENERATED_CIRCUITS_SIZE_2_1;
   const auto& circuits2       = groupSize == 1 ? PRE_GENERATED_CIRCUITS_SIZE_1_2
@@ -41,18 +41,18 @@ void addPreGeneratedCircuits(QuantumComputation& circuit1,
   const auto x2          = circuits2[randomIndex];
   for (auto gateType : x1) {
     if (gateType == X) { // add CNOT
-      circuit1.emplace_back<StandardOperation>(n, groupBeginIndex,
+      circuit1.emplace_back<StandardOperation>(groupBeginIndex,
                                                groupBeginIndex + 1, gateType);
     } else {
-      circuit1.emplace_back<StandardOperation>(n, groupBeginIndex, gateType);
+      circuit1.emplace_back<StandardOperation>(groupBeginIndex, gateType);
     }
   }
   for (auto gateType : x2) {
     if (gateType == X) { // add CNOT
-      circuit2.emplace_back<StandardOperation>(n, groupBeginIndex,
+      circuit2.emplace_back<StandardOperation>(groupBeginIndex,
                                                groupBeginIndex + 1, gateType);
     } else {
-      circuit2.emplace_back<StandardOperation>(n, groupBeginIndex, gateType);
+      circuit2.emplace_back<StandardOperation>(groupBeginIndex, gateType);
     }
   }
 }
@@ -108,7 +108,7 @@ fiveDiffferentRandomNumbers(const qc::Qubit min, const qc::Qubit max,
 }
 
 StandardOperation convertToStandardOperation(
-    const size_t n, const size_t nrQubits, const OpType randomOpType,
+    const size_t nrQubits, const OpType randomOpType,
     const qc::Qubit randomTarget1, const qc::Qubit randomTarget2,
     const fp randomParameter1, const fp randomParameter2,
     const fp randomParameter3, const Controls& randomControls) {
@@ -122,7 +122,7 @@ StandardOperation convertToStandardOperation(
   case qc::DCX:
   case qc::ECR:
     if (nrQubits > 1) {
-      return {n, randomControls, Targets{randomTarget1, randomTarget2},
+      return {randomControls, Targets{randomTarget1, randomTarget2},
               randomOpType};
     }
     break;
@@ -133,7 +133,7 @@ StandardOperation convertToStandardOperation(
   case qc::RZZ:
   case qc::RZX:
     if (nrQubits > 1) {
-      return {n, randomControls, Targets{randomTarget1, randomTarget2},
+      return {randomControls, Targets{randomTarget1, randomTarget2},
               randomOpType, std::vector<fp>{randomParameter1}};
     }
     break;
@@ -142,7 +142,7 @@ StandardOperation convertToStandardOperation(
   case qc::XXminusYY:
   case qc::XXplusYY:
     if (nrQubits > 1) {
-      return {n, randomControls, Targets{randomTarget1, randomTarget2},
+      return {randomControls, Targets{randomTarget1, randomTarget2},
               randomOpType,
               std::vector<fp>{randomParameter1, randomParameter2}};
     }
@@ -162,32 +162,31 @@ StandardOperation convertToStandardOperation(
   case qc::Vdg:
   case qc::SX:
   case qc::SXdg:
-    return {n, randomControls, randomTarget1, randomOpType};
+    return {randomControls, randomTarget1, randomOpType};
     // one target and three parameters
   case qc::U:
     return {
-        n, randomControls, randomTarget1, randomOpType,
+        randomControls, randomTarget1, randomOpType,
         std::vector<fp>{randomParameter1, randomParameter2, randomParameter3}};
     // one target and two parameters
   case qc::U2:
-    return {n, randomControls, randomTarget1, randomOpType,
+    return {randomControls, randomTarget1, randomOpType,
             std::vector<fp>{randomParameter1, randomParameter2}};
     // one target and one parameter
   case qc::P:
   case qc::RX:
   case qc::RY:
   case qc::RZ:
-    return {n, randomControls, randomTarget1, randomOpType,
+    return {randomControls, randomTarget1, randomOpType,
             std::vector<fp>{randomParameter1}};
   default:
-    return {n, randomTarget1, qc::I};
+    return {randomTarget1, qc::I};
   }
-  return {n, randomTarget1, qc::I};
+  return {randomTarget1, qc::I};
 }
 
 StandardOperation
-makeRandomStandardOperation(const size_t n, const qc::Qubit nrQubits,
-                            const qc::Qubit  min,
+makeRandomStandardOperation(const qc::Qubit nrQubits, const qc::Qubit min,
                             std::mt19937_64& randomGenerator) {
   const auto randomNumbers =
       fiveDiffferentRandomNumbers(min, min + nrQubits, randomGenerator);
@@ -221,7 +220,7 @@ makeRandomStandardOperation(const size_t n, const qc::Qubit nrQubits,
   const fp randomParameter2 = randomDistrParameters(randomGenerator);
   const fp randomParameter3 = randomDistrParameters(randomGenerator);
   return convertToStandardOperation(
-      n, nrQubits, randomOpType, randomTarget1, randomTarget2, randomParameter1,
+      nrQubits, randomOpType, randomTarget1, randomTarget2, randomParameter1,
       randomParameter2, randomParameter3, randomControls);
 }
 
@@ -263,7 +262,7 @@ generatePartiallyEquivalentCircuits(const size_t n, const qc::Qubit d,
   // Generate a random subcircuit with d qubits and 3*d gates to apply
   // on both circuits, but all the Toffoli gates in circuit2 are decomposed
   for (qc::Qubit i = 0U; i < 3 * d; i++) {
-    const auto op = makeRandomStandardOperation(n, d, 0, randomGenerator);
+    const auto op = makeRandomStandardOperation(d, 0, randomGenerator);
     addStandardOperationToCircuit(circuit1, op, false);
     addStandardOperationToCircuit(circuit2, op, true);
   }
@@ -282,7 +281,7 @@ generatePartiallyEquivalentCircuits(const size_t n, const qc::Qubit d,
       groupSize = randomDistrGroupSize(randomGenerator);
     }
 
-    addPreGeneratedCircuits(circuit1, circuit2, n, groupBeginIndex, groupSize);
+    addPreGeneratedCircuits(circuit1, circuit2, groupBeginIndex, groupSize);
 
     groupBeginIndex += groupSize;
   }
@@ -296,12 +295,10 @@ generatePartiallyEquivalentCircuits(const size_t n, const qc::Qubit d,
     const qc::Qubit notMQubits = d - m;
     for (qc::Qubit i = 0U; i < notMQubits; i++) {
       addStandardOperationToCircuit(
-          circuit1,
-          makeRandomStandardOperation(n, notMQubits, m, randomGenerator),
+          circuit1, makeRandomStandardOperation(notMQubits, m, randomGenerator),
           false);
       addStandardOperationToCircuit(
-          circuit2,
-          makeRandomStandardOperation(n, notMQubits, m, randomGenerator),
+          circuit2, makeRandomStandardOperation(notMQubits, m, randomGenerator),
           false);
     }
   }


### PR DESCRIPTION
## Description

This PR pulls in the changes from cda-tum/mqt-core#358, which considerably changes the way matrix decision diagrams are represented. Particularly, any node resembling the identity is now eliminated and only implicitly represented.
This further compacts the representation of quantum gates and makes the identity the most compact it can be---a single terminal node.
The overall performance improvements are still to be evaluated. Surprisingly few changes were needed to make this work in QCEC.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
