### PR TITLE
🧱 switch to dedicated reusable MQT workflows

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,6 +3,9 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/workflows/cd.yml
 
 jobs:
   python-packaging:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   python-packaging:
     name: 🐍 Packaging
-    uses: cda-tum/mqt-core/.github/workflows/reusable-python-packaging.yml@v2.4.2
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-packaging.yml@v1.0.0
 
   deploy:
     if: github.event_name == 'release' && github.event.action == 'published'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,13 @@ concurrency:
 jobs:
   change-detection:
     name: 🔍 Change
-    uses: cda-tum/mqt-core/.github/workflows/reusable-change-detection.yml@v2.4.2
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-change-detection.yml@v1.0.0
 
   cpp-tests:
     name: 🇨‌ Test
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cpp-tests)
-    uses: cda-tum/mqt-core/.github/workflows/reusable-cpp-ci.yml@v2.4.2
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-ci.yml@v1.0.0
     secrets:
       token: ${{ secrets.CODECOV_TOKEN }}
     with:
@@ -33,13 +33,13 @@ jobs:
     name: 🇨‌ Lint
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cpp-linter)
-    uses: cda-tum/mqt-core/.github/workflows/reusable-cpp-linter.yml@v2.4.2
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-linter.yml@v1.0.0
 
   python-tests:
     name: 🐍 Test
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-python-tests)
-    uses: cda-tum/mqt-core/.github/workflows/reusable-python-ci.yml@v2.4.2
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-ci.yml@v1.0.0
     secrets:
       token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -47,7 +47,7 @@ jobs:
     name: 📝 CodeQL
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-code-ql)
-    uses: cda-tum/mqt-core/.github/workflows/reusable-code-ql.yml@v2.4.2
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-code-ql.yml@v1.0.0
 
   required-checks-pass: # This job does nothing and is only used for branch protection
     name: 🚦 Check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     with:
       cmake-args: ""
       cmake-args-ubuntu: -G Ninja
-      cmake-args-macos: -G Ninja
+      cmake-args-macos: -G Ninja -DMQT_CORE_WITH_GMP=ON
       cmake-args-windows: -T ClangCL
 
   cpp-linter:


### PR DESCRIPTION
## Description

This PR switches the reusable workflows from MQT Core to the ones hosted at https://github.com/cda-tum/mqt-workflows. This creates a better separation of concerns and allows for separate versioning of the workflows and the MQT Core library.

Furthermore, this PR adapts the configuration of the continuous deployment job so that the job is also triggered if the respective workflow file is updated. This should help to catch errors as early as possible when dependabot updates the workflow.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
