### PR TITLE
🚨 Fix new warnings revealed by clang-tidy 18

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,7 +1,3 @@
 BasedOnStyle: LLVM
-AlignConsecutiveAssignments: Consecutive
-AlignConsecutiveDeclarations: Consecutive
 IncludeBlocks: Regroup
-KeepEmptyLinesAtTheStartOfBlocks: false
 PointerAlignment: Left
-SpacesInContainerLiterals: false

--- a/include/Configuration.hpp
+++ b/include/Configuration.hpp
@@ -25,25 +25,25 @@ public:
   struct Execution {
     dd::fp numericalTolerance = dd::RealNumber::eps;
 
-    bool        parallel = true;
+    bool parallel = true;
     std::size_t nthreads = std::max(2U, std::thread::hardware_concurrency());
-    double      timeout  = 0.; // in seconds
+    double timeout = 0.; // in seconds
 
     bool runConstructionChecker = false;
-    bool runSimulationChecker   = true;
-    bool runAlternatingChecker  = true;
-    bool runZXChecker           = true;
+    bool runSimulationChecker = true;
+    bool runAlternatingChecker = true;
+    bool runZXChecker = true;
   };
 
   // configuration options for pre-check optimizations
   struct Optimizations {
-    bool fuseSingleQubitGates             = true;
-    bool reconstructSWAPs                 = true;
+    bool fuseSingleQubitGates = true;
+    bool reconstructSWAPs = true;
     bool removeDiagonalGatesBeforeMeasure = false;
-    bool transformDynamicCircuit          = false;
-    bool reorderOperations                = true;
-    bool backpropagateOutputPermutation   = false;
-    bool elidePermutations                = true;
+    bool transformDynamicCircuit = false;
+    bool reorderOperations = true;
+    bool backpropagateOutputPermutation = false;
+    bool elidePermutations = true;
   };
 
   // configuration options for application schemes
@@ -56,30 +56,30 @@ public:
         ApplicationSchemeType::Proportional;
 
     // options for the gate cost application scheme
-    std::string  profile;
+    std::string profile;
     CostFunction costFunction = &legacyCostFunction;
   };
 
   struct Functionality {
-    double traceThreshold          = 1e-8;
-    bool   checkPartialEquivalence = false;
+    double traceThreshold = 1e-8;
+    bool checkPartialEquivalence = false;
   };
 
   // configuration options for the simulation scheme
   struct Simulation {
-    double      fidelityThreshold = 1e-8;
-    std::size_t maxSims           = computeMaxSims();
-    StateType   stateType         = StateType::ComputationalBasis;
-    std::size_t seed              = 0U;
-    bool        storeCEXinput     = false;
-    bool        storeCEXoutput    = false;
+    double fidelityThreshold = 1e-8;
+    std::size_t maxSims = computeMaxSims();
+    StateType stateType = StateType::ComputationalBasis;
+    std::size_t seed = 0U;
+    bool storeCEXinput = false;
+    bool storeCEXoutput = false;
 
     // this function makes sure that the maximum number of simulations is
     // configured properly.
     static std::size_t computeMaxSims() {
-      constexpr std::size_t defaultMaxSims                 = 16U;
+      constexpr std::size_t defaultMaxSims = 16U;
       constexpr std::size_t defaultConfiguredOtherCheckers = 2U;
-      const auto            systemThreads = std::thread::hardware_concurrency();
+      const auto systemThreads = std::thread::hardware_concurrency();
       // catch the case where hardware_concurrency() returns 0 or the other
       // pre-configured checkers already use up all the available threads
       if (systemThreads < defaultConfiguredOtherCheckers) {
@@ -91,15 +91,15 @@ public:
   };
 
   struct Parameterized {
-    double      parameterizedTol          = 1e-12;
+    double parameterizedTol = 1e-12;
     std::size_t nAdditionalInstantiations = 0;
   };
 
-  Execution     execution{};
+  Execution execution{};
   Optimizations optimizations{};
-  Application   application{};
+  Application application{};
   Functionality functionality{};
-  Simulation    simulation{};
+  Simulation simulation{};
   Parameterized parameterized{};
 
   [[nodiscard]] bool anythingToExecute() const noexcept;

--- a/include/EquivalenceCheckingManager.hpp
+++ b/include/EquivalenceCheckingManager.hpp
@@ -54,11 +54,11 @@ public:
 
     EquivalenceCriterion equivalence = EquivalenceCriterion::NoInformation;
 
-    std::size_t startedSimulations   = 0U;
+    std::size_t startedSimulations = 0U;
     std::size_t performedSimulations = 0U;
-    dd::CVec    cexInput;
-    dd::CVec    cexOutput1;
-    dd::CVec    cexOutput2;
+    dd::CVec cexInput;
+    dd::CVec cexOutput1;
+    dd::CVec cexOutput2;
     std::size_t performedInstantiations = 0U;
 
     nlohmann::json checkerResults = nlohmann::json::array();
@@ -85,7 +85,7 @@ public:
     }
     [[nodiscard]] std::string toString() const { return json().dump(2); }
     friend std::ostream&
-    operator<<(std::ostream&                              os,
+    operator<<(std::ostream& os,
                const EquivalenceCheckingManager::Results& res) {
       return os << res.toString();
     }
@@ -107,7 +107,7 @@ public:
     return results.equivalence;
   }
   [[nodiscard]] Configuration getConfiguration() const { return configuration; }
-  [[nodiscard]] Results       getResults() const { return results; }
+  [[nodiscard]] Results getResults() const { return results; }
 
   // convenience functions for changing the configuration after the manager has
   // been constructed: Execution: These settings may be changed to influence
@@ -138,9 +138,9 @@ public:
 
   void disableAllCheckers() {
     configuration.execution.runConstructionChecker = false;
-    configuration.execution.runZXChecker           = false;
-    configuration.execution.runSimulationChecker   = false;
-    configuration.execution.runAlternatingChecker  = false;
+    configuration.execution.runZXChecker = false;
+    configuration.execution.runSimulationChecker = false;
+    configuration.execution.runAlternatingChecker = false;
   }
 
   // Optimization: Optimizations are applied during initialization. Already
@@ -251,11 +251,11 @@ protected:
   Configuration configuration{};
 
   StateGenerator stateGenerator;
-  std::mutex     stateGeneratorMutex;
+  std::mutex stateGeneratorMutex;
 
-  bool                                             done{false};
-  std::condition_variable                          doneCond;
-  std::mutex                                       doneMutex;
+  bool done{false};
+  std::condition_variable doneCond;
+  std::mutex doneMutex;
   std::vector<std::unique_ptr<EquivalenceChecker>> checkers;
 
   Results results{};
@@ -315,7 +315,7 @@ protected:
   /// once it is done.
   /// \return A future that can be used to wait for the checker to finish.
   template <class Checker>
-  std::future<void> asyncRunChecker(const std::size_t             id,
+  std::future<void> asyncRunChecker(const std::size_t id,
                                     ThreadSafeQueue<std::size_t>& queue) {
     static_assert(std::is_base_of_v<EquivalenceChecker, Checker>,
                   "Checker must be derived from EquivalenceChecker");

--- a/include/EquivalenceCheckingManager.hpp
+++ b/include/EquivalenceCheckingManager.hpp
@@ -9,8 +9,12 @@
 #include "EquivalenceCriterion.hpp"
 #include "QuantumComputation.hpp"
 #include "ThreadSafeQueue.hpp"
+#include "checker/EquivalenceChecker.hpp"
 #include "checker/dd/DDSimulationChecker.hpp"
+#include "checker/dd/applicationscheme/ApplicationScheme.hpp"
+#include "checker/dd/applicationscheme/GateCostApplicationScheme.hpp"
 #include "checker/dd/simulation/StateGenerator.hpp"
+#include "checker/dd/simulation/StateType.hpp"
 #include "dd/ComplexNumbers.hpp"
 #include "dd/DDDefinitions.hpp"
 

--- a/include/EquivalenceCriterion.hpp
+++ b/include/EquivalenceCriterion.hpp
@@ -10,13 +10,13 @@
 
 namespace ec {
 enum class EquivalenceCriterion {
-  NotEquivalent             = 0,
-  Equivalent                = 1,
-  NoInformation             = 2,
-  ProbablyEquivalent        = 3,
+  NotEquivalent = 0,
+  Equivalent = 1,
+  NoInformation = 2,
+  ProbablyEquivalent = 3,
   EquivalentUpToGlobalPhase = 4,
-  EquivalentUpToPhase       = 5,
-  ProbablyNotEquivalent     = 6
+  EquivalentUpToPhase = 5,
+  ProbablyNotEquivalent = 6
 };
 
 inline std::string toString(const EquivalenceCriterion& criterion) noexcept {
@@ -65,7 +65,7 @@ inline EquivalenceCriterion fromString(const std::string& criterion) noexcept {
   return EquivalenceCriterion::NoInformation;
 }
 
-inline std::istream& operator>>(std::istream&         in,
+inline std::istream& operator>>(std::istream& in,
                                 EquivalenceCriterion& criterion) {
   std::string token;
   in >> token;
@@ -79,7 +79,7 @@ inline std::istream& operator>>(std::istream&         in,
   return in;
 }
 
-inline std::ostream& operator<<(std::ostream&               out,
+inline std::ostream& operator<<(std::ostream& out,
                                 const EquivalenceCriterion& criterion) {
   out << toString(criterion);
   return out;

--- a/include/EquivalenceCriterion.hpp
+++ b/include/EquivalenceCriterion.hpp
@@ -5,11 +5,12 @@
 
 #pragma once
 
-#include <exception>
+#include <cstdint>
 #include <iostream>
+#include <string>
 
 namespace ec {
-enum class EquivalenceCriterion {
+enum class EquivalenceCriterion : std::uint8_t {
   NotEquivalent = 0,
   Equivalent = 1,
   NoInformation = 2,

--- a/include/ThreadSafeQueue.hpp
+++ b/include/ThreadSafeQueue.hpp
@@ -38,10 +38,10 @@ public:
     auto p = std::make_unique<Node>();
     {
       const std::lock_guard tailLock(tailMutex);
-      tail->data          = data;
+      tail->data = data;
       Node* const newTail = p.get();
-      tail->next          = std::move(p);
-      tail                = newTail;
+      tail->next = std::move(p);
+      tail = newTail;
     }
     dataCond.notify_one();
   }
@@ -52,13 +52,13 @@ public:
 
 private:
   struct Node {
-    std::shared_ptr<T>    data;
+    std::shared_ptr<T> data;
     std::unique_ptr<Node> next;
   };
-  std::mutex              headMutex;
-  std::unique_ptr<Node>   head = std::make_unique<Node>();
-  std::mutex              tailMutex;
-  Node*                   tail;
+  std::mutex headMutex;
+  std::unique_ptr<Node> head = std::make_unique<Node>();
+  std::mutex tailMutex;
+  Node* tail;
   std::condition_variable dataCond;
 
   auto getTail() {
@@ -68,7 +68,7 @@ private:
 
   auto popHead() {
     auto oldHead = std::move(head);
-    head         = std::move(oldHead->next);
+    head = std::move(oldHead->next);
     return oldHead;
   }
 

--- a/include/checker/EquivalenceChecker.hpp
+++ b/include/checker/EquivalenceChecker.hpp
@@ -20,7 +20,7 @@ class EquivalenceChecker {
 public:
   EquivalenceChecker(const qc::QuantumComputation& circ1,
                      const qc::QuantumComputation& circ2,
-                     Configuration                 config) noexcept
+                     Configuration config) noexcept
       : qc1(&circ1), qc2(&circ2),
         nqubits(std::max(qc1->getNqubits(), qc2->getNqubits())),
         configuration(std::move(config)) {};
@@ -50,7 +50,7 @@ protected:
   Configuration configuration;
 
   EquivalenceCriterion equivalence = EquivalenceCriterion::NoInformation;
-  double               runtime{};
+  double runtime{};
 
 private:
   std::atomic<bool> done{false};

--- a/include/checker/dd/DDAlternatingChecker.hpp
+++ b/include/checker/dd/DDAlternatingChecker.hpp
@@ -17,7 +17,7 @@ class DDAlternatingChecker final
 public:
   DDAlternatingChecker(const qc::QuantumComputation& circ1,
                        const qc::QuantumComputation& circ2,
-                       ec::Configuration             config)
+                       ec::Configuration config)
       : DDEquivalenceChecker(circ1, circ2, std::move(config)) {
     // gates from the second circuit shall be applied "from the right"
     taskManager2.flipDirection();
@@ -47,10 +47,10 @@ public:
 private:
   qc::MatrixDD functionality{};
 
-  void                 initialize() override;
-  void                 execute() override;
-  void                 finish() override;
-  void                 postprocess() override;
+  void initialize() override;
+  void execute() override;
+  void finish() override;
+  void postprocess() override;
   EquivalenceCriterion checkEquivalence() override;
 
   // at some point this routine should probably make its way into the QFR

--- a/include/checker/dd/DDAlternatingChecker.hpp
+++ b/include/checker/dd/DDAlternatingChecker.hpp
@@ -5,11 +5,16 @@
 
 #pragma once
 
+#include "Configuration.hpp"
 #include "DDEquivalenceChecker.hpp"
 #include "DDPackageConfigs.hpp"
+#include "EquivalenceCriterion.hpp"
+#include "QuantumComputation.hpp"
 #include "applicationscheme/LookaheadApplicationScheme.hpp"
+#include "dd/Package_fwd.hpp"
 
 #include <nlohmann/json_fwd.hpp>
+#include <utility>
 
 namespace ec {
 class DDAlternatingChecker final

--- a/include/checker/dd/DDConstructionChecker.hpp
+++ b/include/checker/dd/DDConstructionChecker.hpp
@@ -23,7 +23,7 @@ class DDConstructionChecker final
 public:
   DDConstructionChecker(const qc::QuantumComputation& circ1,
                         const qc::QuantumComputation& circ2,
-                        ec::Configuration             config)
+                        ec::Configuration config)
       : DDEquivalenceChecker(circ1, circ2, std::move(config)) {
     if (this->configuration.application.constructionScheme ==
         ApplicationSchemeType::Lookahead) {

--- a/include/checker/dd/DDEquivalenceChecker.hpp
+++ b/include/checker/dd/DDEquivalenceChecker.hpp
@@ -24,7 +24,7 @@ class DDEquivalenceChecker : public EquivalenceChecker {
 public:
   DDEquivalenceChecker(const qc::QuantumComputation& circ1,
                        const qc::QuantumComputation& circ2,
-                       Configuration                 config)
+                       Configuration config)
       : EquivalenceChecker(circ1, circ2, std::move(config)),
         dd(std::make_unique<dd::Package<Config>>(nqubits)),
         taskManager1(TaskManager<DDType, Config>(circ1, *dd)),

--- a/include/checker/dd/DDPackageConfigs.hpp
+++ b/include/checker/dd/DDPackageConfigs.hpp
@@ -12,61 +12,61 @@
 namespace ec {
 struct SimulationDDPackageConfig : public dd::DDPackageConfig {
   // simulation requires more resources for vectors.
-  static constexpr std::size_t UT_VEC_NBUCKET            = 65'536U;
-  static constexpr std::size_t CT_VEC_ADD_NBUCKET        = 65'536U;
-  static constexpr std::size_t CT_MAT_VEC_MULT_NBUCKET   = 65'536U;
+  static constexpr std::size_t UT_VEC_NBUCKET = 65'536U;
+  static constexpr std::size_t CT_VEC_ADD_NBUCKET = 65'536U;
+  static constexpr std::size_t CT_MAT_VEC_MULT_NBUCKET = 65'536U;
   static constexpr std::size_t CT_VEC_INNER_PROD_NBUCKET = 32'768U;
 
   // simulation only needs matrices for representing operations. Hence, very
   // little is needed here.
-  static constexpr std::size_t UT_MAT_NBUCKET                 = 128U;
+  static constexpr std::size_t UT_MAT_NBUCKET = 128U;
   static constexpr std::size_t UT_MAT_INITIAL_ALLOCATION_SIZE = 32U;
 
   // simulation needs no matrix addition, conjugate transposition, matrix-matrix
   // multiplication, or kronecker products.
-  static constexpr std::size_t CT_MAT_ADD_NBUCKET        = 1U;
+  static constexpr std::size_t CT_MAT_ADD_NBUCKET = 1U;
   static constexpr std::size_t CT_MAT_CONJ_TRANS_NBUCKET = 1U;
-  static constexpr std::size_t CT_MAT_MAT_MULT_NBUCKET   = 1U;
-  static constexpr std::size_t CT_VEC_KRON_NBUCKET       = 1U;
-  static constexpr std::size_t CT_MAT_KRON_NBUCKET       = 1U;
+  static constexpr std::size_t CT_MAT_MAT_MULT_NBUCKET = 1U;
+  static constexpr std::size_t CT_VEC_KRON_NBUCKET = 1U;
+  static constexpr std::size_t CT_MAT_KRON_NBUCKET = 1U;
 };
 
 struct ConstructionDDPackageConfig : public dd::DDPackageConfig {
   // construction requires more resources for matrices.
-  static constexpr std::size_t UT_MAT_NBUCKET            = 65'536U;
-  static constexpr std::size_t CT_MAT_ADD_NBUCKET        = 65'536U;
-  static constexpr std::size_t CT_MAT_MAT_MULT_NBUCKET   = 65'536U;
+  static constexpr std::size_t UT_MAT_NBUCKET = 65'536U;
+  static constexpr std::size_t CT_MAT_ADD_NBUCKET = 65'536U;
+  static constexpr std::size_t CT_MAT_MAT_MULT_NBUCKET = 65'536U;
   static constexpr std::size_t CT_MAT_CONJ_TRANS_NBUCKET = 32'768U;
 
   // construction does not need any vector nodes
-  static constexpr std::size_t UT_VEC_NBUCKET                 = 1U;
+  static constexpr std::size_t UT_VEC_NBUCKET = 1U;
   static constexpr std::size_t UT_VEC_INITIAL_ALLOCATION_SIZE = 1U;
 
   // construction needs no vector addition, matrix-vector multiplication,
   // kronecker products, or inner products.
-  static constexpr std::size_t CT_VEC_ADD_NBUCKET        = 1U;
-  static constexpr std::size_t CT_MAT_VEC_MULT_NBUCKET   = 1U;
-  static constexpr std::size_t CT_VEC_KRON_NBUCKET       = 1U;
-  static constexpr std::size_t CT_MAT_KRON_NBUCKET       = 1U;
+  static constexpr std::size_t CT_VEC_ADD_NBUCKET = 1U;
+  static constexpr std::size_t CT_MAT_VEC_MULT_NBUCKET = 1U;
+  static constexpr std::size_t CT_VEC_KRON_NBUCKET = 1U;
+  static constexpr std::size_t CT_MAT_KRON_NBUCKET = 1U;
   static constexpr std::size_t CT_VEC_INNER_PROD_NBUCKET = 1U;
 };
 
 struct AlternatingDDPackageConfig : public dd::DDPackageConfig {
   // The alternating checker requires more resources for matrices.
-  static constexpr std::size_t UT_MAT_NBUCKET          = 65'536U;
-  static constexpr std::size_t CT_MAT_ADD_NBUCKET      = 65'536U;
+  static constexpr std::size_t UT_MAT_NBUCKET = 65'536U;
+  static constexpr std::size_t CT_MAT_ADD_NBUCKET = 65'536U;
   static constexpr std::size_t CT_MAT_MAT_MULT_NBUCKET = 65'536U;
 
   // The alternating checker does not need any vector nodes
-  static constexpr std::size_t UT_VEC_NBUCKET                 = 1U;
+  static constexpr std::size_t UT_VEC_NBUCKET = 1U;
   static constexpr std::size_t UT_VEC_INITIAL_ALLOCATION_SIZE = 1U;
 
   // The alternating needs no vector addition, matrix-vector multiplication,
   // kronecker products, or inner products.
-  static constexpr std::size_t CT_VEC_ADD_NBUCKET        = 1U;
-  static constexpr std::size_t CT_MAT_VEC_MULT_NBUCKET   = 1U;
-  static constexpr std::size_t CT_VEC_KRON_NBUCKET       = 1U;
-  static constexpr std::size_t CT_MAT_KRON_NBUCKET       = 1U;
+  static constexpr std::size_t CT_VEC_ADD_NBUCKET = 1U;
+  static constexpr std::size_t CT_MAT_VEC_MULT_NBUCKET = 1U;
+  static constexpr std::size_t CT_VEC_KRON_NBUCKET = 1U;
+  static constexpr std::size_t CT_MAT_KRON_NBUCKET = 1U;
   static constexpr std::size_t CT_VEC_INNER_PROD_NBUCKET = 1U;
 };
 } // namespace ec

--- a/include/checker/dd/DDSimulationChecker.hpp
+++ b/include/checker/dd/DDSimulationChecker.hpp
@@ -38,7 +38,7 @@ public:
     return taskManager2.getInternalState().getVector();
   }
 
-  void json(nlohmann::json& j) const noexcept override;
+  void json(nlohmann::basic_json<>& j) const noexcept override;
 
 private:
   // the initial state used for simulation. defaults to the all-zero state

--- a/include/checker/dd/DDSimulationChecker.hpp
+++ b/include/checker/dd/DDSimulationChecker.hpp
@@ -24,7 +24,7 @@ class DDSimulationChecker final
 public:
   DDSimulationChecker(const qc::QuantumComputation& circ1,
                       const qc::QuantumComputation& circ2,
-                      Configuration                 configuration);
+                      Configuration configuration);
 
   void setRandomInitialState(StateGenerator& generator);
 

--- a/include/checker/dd/TaskManager.hpp
+++ b/include/checker/dd/TaskManager.hpp
@@ -32,7 +32,7 @@ public:
       : TaskManager(circ, dd, Direction::Left) {}
 
   void reset() noexcept {
-    iterator    = qc->begin();
+    iterator = qc->begin();
     permutation = qc->initialLayout;
   }
 
@@ -145,11 +145,11 @@ public:
 
 private:
   const qc::QuantumComputation* qc{};
-  DDPackage*                    package;
-  ec::Direction                 direction = Direction::Left;
-  qc::Permutation               permutation{};
-  decltype(qc->begin())         iterator;
-  decltype(qc->end())           end;
-  DDType                        internalState{};
+  DDPackage* package;
+  ec::Direction direction = Direction::Left;
+  qc::Permutation permutation{};
+  decltype(qc->begin()) iterator;
+  decltype(qc->end()) end;
+  DDType internalState{};
 };
 } // namespace ec

--- a/include/checker/dd/applicationscheme/ApplicationScheme.hpp
+++ b/include/checker/dd/applicationscheme/ApplicationScheme.hpp
@@ -14,10 +14,10 @@
 namespace ec {
 // A list of application schemes that implement the below interface
 enum class ApplicationSchemeType {
-  Sequential   = 0,
-  OneToOne     = 1,
-  Lookahead    = 2,
-  GateCost     = 3,
+  Sequential = 0,
+  OneToOne = 1,
+  Lookahead = 2,
+  GateCost = 3,
   Proportional = 4
 };
 
@@ -62,7 +62,7 @@ applicationSchemeFromString(const std::string& applicationScheme) noexcept {
   return ApplicationSchemeType::Proportional;
 }
 
-inline std::istream& operator>>(std::istream&          in,
+inline std::istream& operator>>(std::istream& in,
                                 ApplicationSchemeType& applicationScheme) {
   std::string token;
   in >> token;

--- a/include/checker/dd/applicationscheme/ApplicationScheme.hpp
+++ b/include/checker/dd/applicationscheme/ApplicationScheme.hpp
@@ -5,15 +5,17 @@
 
 #pragma once
 
-#include "QuantumComputation.hpp"
 #include "checker/dd/TaskManager.hpp"
 
+#include <cstddef>
+#include <cstdint>
 #include <iostream>
-#include <stdexcept>
+#include <string>
+#include <utility>
 
 namespace ec {
 // A list of application schemes that implement the below interface
-enum class ApplicationSchemeType {
+enum class ApplicationSchemeType : std::uint8_t {
   Sequential = 0,
   OneToOne = 1,
   Lookahead = 2,

--- a/include/checker/dd/applicationscheme/GateCostApplicationScheme.hpp
+++ b/include/checker/dd/applicationscheme/GateCostApplicationScheme.hpp
@@ -44,8 +44,8 @@ class GateCostApplicationScheme final
 public:
   GateCostApplicationScheme(TaskManager<DDType, Config>& tm1,
                             TaskManager<DDType, Config>& tm2,
-                            const CostFunction&          costFunction,
-                            const bool                   singleQubitGateFusion)
+                            const CostFunction& costFunction,
+                            const bool singleQubitGateFusion)
       : ApplicationScheme<DDType, Config>(tm1, tm2),
         singleQubitGateFusionEnabled(singleQubitGateFusion) {
     populateLookupTable(costFunction, tm1.getCircuit());
@@ -54,8 +54,8 @@ public:
 
   GateCostApplicationScheme(TaskManager<DDType, Config>& tm1,
                             TaskManager<DDType, Config>& tm2,
-                            const std::string&           filename,
-                            const bool                   singleQubitGateFusion)
+                            const std::string& filename,
+                            const bool singleQubitGateFusion)
       : ApplicationScheme<DDType, Config>(tm1, tm2),
         singleQubitGateFusionEnabled(singleQubitGateFusion) {
     populateLookupTable(filename);
@@ -85,15 +85,15 @@ public:
 
 private:
   GateCostLookupTable gateCostLookupTable;
-  bool                singleQubitGateFusionEnabled;
+  bool singleQubitGateFusionEnabled;
 
   template <class CostFun>
-  void populateLookupTable(CostFun                       costFunction,
+  void populateLookupTable(CostFun costFunction,
                            const qc::QuantumComputation* qc) {
     for (const auto& op : *qc) {
-      const auto type      = op->getType();
+      const auto type = op->getType();
       const auto nControls = op->getNcontrols();
-      const auto key       = GateCostLookupTableKeyType{type, nControls};
+      const auto key = GateCostLookupTableKeyType{type, nControls};
       if (const auto it = gateCostLookupTable.find(key);
           it == gateCostLookupTable.end()) {
         const auto cost = costFunction(key);
@@ -114,9 +114,9 @@ private:
     populateLookupTable(ifs);
   }
   void populateLookupTable(std::istream& is) {
-    qc::OpType  opType    = qc::OpType::None;
+    qc::OpType opType = qc::OpType::None;
     std::size_t nControls = 0U;
-    std::size_t cost      = 1U;
+    std::size_t cost = 1U;
 
     std::string line;
     while (std::getline(is, line)) {

--- a/include/checker/dd/applicationscheme/LookaheadApplicationScheme.hpp
+++ b/include/checker/dd/applicationscheme/LookaheadApplicationScheme.hpp
@@ -43,10 +43,10 @@ public:
     }
 
     // compute both possible applications and measure the resulting size
-    auto       saved = *internalState;
-    const auto dd1   = package->multiply(op1, saved);
+    auto saved = *internalState;
+    const auto dd1 = package->multiply(op1, saved);
     const auto size1 = dd1.size();
-    const auto dd2   = package->multiply(saved, op2);
+    const auto dd2 = package->multiply(saved, op2);
 
     // greedily chose the smaller resulting decision diagram
     if (const auto size2 = dd2.size(); size1 <= size2) {
@@ -75,14 +75,14 @@ public:
 
 private:
   qc::MatrixDD op1{};
-  bool         cached1 = false;
+  bool cached1 = false;
 
   qc::MatrixDD op2{};
-  bool         cached2 = false;
+  bool cached2 = false;
 
   // the lookahead application scheme maintains links to an internal state to
   // manipulate and a package to use
-  qc::MatrixDD*        internalState{};
+  qc::MatrixDD* internalState{};
   dd::Package<Config>* package{};
 };
 } // namespace ec

--- a/include/checker/dd/applicationscheme/LookaheadApplicationScheme.hpp
+++ b/include/checker/dd/applicationscheme/LookaheadApplicationScheme.hpp
@@ -6,6 +6,13 @@
 #pragma once
 
 #include "ApplicationScheme.hpp"
+#include "checker/dd/TaskManager.hpp"
+#include "dd/Package.hpp"
+#include "dd/Package_fwd.hpp"
+
+#include <cassert>
+#include <cstddef>
+#include <utility>
 
 namespace ec {
 template <class Config>

--- a/include/checker/dd/applicationscheme/OneToOneApplicationScheme.hpp
+++ b/include/checker/dd/applicationscheme/OneToOneApplicationScheme.hpp
@@ -6,6 +6,10 @@
 #pragma once
 
 #include "ApplicationScheme.hpp"
+#include "checker/dd/TaskManager.hpp"
+
+#include <cstddef>
+#include <utility>
 
 namespace ec {
 template <class DDType, class Config>

--- a/include/checker/dd/applicationscheme/SequentialApplicationScheme.hpp
+++ b/include/checker/dd/applicationscheme/SequentialApplicationScheme.hpp
@@ -6,6 +6,10 @@
 #pragma once
 
 #include "ApplicationScheme.hpp"
+#include "checker/dd/TaskManager.hpp"
+
+#include <cstddef>
+#include <utility>
 
 namespace ec {
 template <class DDType, class Config>
@@ -23,7 +27,7 @@ public:
   }
 
 private:
-  const std::size_t gates1;
-  const std::size_t gates2;
+  std::size_t gates1;
+  std::size_t gates2;
 };
 } // namespace ec

--- a/include/checker/dd/simulation/StateGenerator.hpp
+++ b/include/checker/dd/simulation/StateGenerator.hpp
@@ -26,7 +26,7 @@ public:
   qc::VectorDD
   generateRandomState(dd::Package<Config>& dd, const std::size_t totalQubits,
                       const std::size_t ancillaryQubits = 0U,
-                      const StateType   type = StateType::ComputationalBasis) {
+                      const StateType type = StateType::ComputationalBasis) {
     switch (type) {
     case ec::StateType::Random1QBasis:
       return generateRandom1QBasisState(dd, totalQubits, ancillaryQubits);
@@ -92,8 +92,8 @@ public:
   template <class Config = dd::DDPackageConfig>
   qc::VectorDD
   generateRandom1QBasisState(dd::Package<Config>& dd,
-                             const std::size_t    totalQubits,
-                             const std::size_t    ancillaryQubits = 0U) {
+                             const std::size_t totalQubits,
+                             const std::size_t ancillaryQubits = 0U) {
     // determine how many qubits truly are random
     const std::size_t randomQubits = totalQubits - ancillaryQubits;
 
@@ -132,8 +132,8 @@ public:
   template <class Config = dd::DDPackageConfig>
   qc::VectorDD
   generateRandomStabilizerState(dd::Package<Config>& dd,
-                                const std::size_t    totalQubits,
-                                const std::size_t    ancillaryQubits = 0U) {
+                                const std::size_t totalQubits,
+                                const std::size_t ancillaryQubits = 0U) {
     // determine how many qubits truly are random
     const std::size_t randomQubits = totalQubits - ancillaryQubits;
 
@@ -165,11 +165,11 @@ public:
   void clear() { generatedComputationalBasisStates.clear(); }
 
 private:
-  std::size_t     seed = 0U;
+  std::size_t seed = 0U;
   std::mt19937_64 mt;
 
   std::unordered_set<std::size_t> generatedComputationalBasisStates{};
-  constexpr static std::size_t    ONE_QUBIT_BASE_ELEMENTS = 6U;
+  constexpr static std::size_t ONE_QUBIT_BASE_ELEMENTS = 6U;
   // this generator produces random bases from the set { |0>, |1>, |+>, |->,
   // |L>, |R> }
   std::uniform_int_distribution<std::size_t> random1QBasisDistribution =

--- a/include/checker/dd/simulation/StateGenerator.hpp
+++ b/include/checker/dd/simulation/StateGenerator.hpp
@@ -7,12 +7,22 @@
 
 #include "StateType.hpp"
 #include "algorithms/RandomCliffordCircuit.hpp"
-#include "checker/dd/TaskManager.hpp"
+#include "dd/DDDefinitions.hpp"
+#include "dd/DDpackageConfig.hpp"
 #include "dd/Package.hpp"
-#include "dd/Simulation.hpp"
+#include "dd/Package_fwd.hpp"
+#include "dd/Simulation.hpp" // IWYU pragma: keep
 
-#include <functional>
+#include <array>
+#include <cassert>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
 #include <random>
+#include <tuple>
+#include <unordered_set>
+#include <vector>
 
 namespace ec {
 class StateGenerator {
@@ -168,7 +178,7 @@ private:
   std::size_t seed = 0U;
   std::mt19937_64 mt;
 
-  std::unordered_set<std::size_t> generatedComputationalBasisStates{};
+  std::unordered_set<std::size_t> generatedComputationalBasisStates;
   constexpr static std::size_t ONE_QUBIT_BASE_ELEMENTS = 6U;
   // this generator produces random bases from the set { |0>, |1>, |+>, |->,
   // |L>, |R> }

--- a/include/checker/dd/simulation/StateType.hpp
+++ b/include/checker/dd/simulation/StateType.hpp
@@ -10,8 +10,8 @@
 namespace ec {
 enum class StateType {
   ComputationalBasis = 0,
-  Random1QBasis      = 1,
-  Stabilizer         = 2
+  Random1QBasis = 1,
+  Stabilizer = 2
 };
 
 inline std::string toString(const StateType& type) noexcept {

--- a/include/checker/dd/simulation/StateType.hpp
+++ b/include/checker/dd/simulation/StateType.hpp
@@ -5,10 +5,12 @@
 
 #pragma once
 
+#include <cstdint>
 #include <iostream>
+#include <string>
 
 namespace ec {
-enum class StateType {
+enum class StateType : std::uint8_t {
   ComputationalBasis = 0,
   Random1QBasis = 1,
   Stabilizer = 2

--- a/include/checker/zx/ZXChecker.hpp
+++ b/include/checker/zx/ZXChecker.hpp
@@ -19,7 +19,7 @@ class ZXEquivalenceChecker : public EquivalenceChecker {
 public:
   ZXEquivalenceChecker(const qc::QuantumComputation& circ1,
                        const qc::QuantumComputation& circ2,
-                       Configuration                 config) noexcept;
+                       Configuration config) noexcept;
 
   EquivalenceCriterion run() override;
 
@@ -30,8 +30,8 @@ public:
 
 private:
   zx::ZXDiagram miter;
-  zx::fp        tolerance;
-  bool          ancilla = false;
+  zx::fp tolerance;
+  bool ancilla = false;
 
   // the following methods are adaptations of the core ZX simplification
   // routines that additionally check a criterion for early termination of the

--- a/include/checker/zx/ZXChecker.hpp
+++ b/include/checker/zx/ZXChecker.hpp
@@ -6,13 +6,16 @@
 #pragma once
 
 #include "Configuration.hpp"
-#include "Definitions.hpp"
 #include "EquivalenceCriterion.hpp"
+#include "Permutation.hpp"
 #include "QuantumComputation.hpp"
 #include "checker/EquivalenceChecker.hpp"
-#include "nlohmann/json.hpp"
-#include "zx/Simplify.hpp"
+#include "zx/Rules.hpp"
+#include "zx/ZXDefinitions.hpp"
 #include "zx/ZXDiagram.hpp"
+
+#include <cstddef>
+#include <nlohmann/json.hpp>
 
 namespace ec {
 class ZXEquivalenceChecker : public EquivalenceChecker {
@@ -23,7 +26,7 @@ public:
 
   EquivalenceCriterion run() override;
 
-  void json(nlohmann::json& j) const noexcept override {
+  void json(nlohmann::basic_json<>& j) const noexcept override {
     EquivalenceChecker::json(j);
     j["checker"] = "zx";
   }

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -6,6 +6,9 @@
 
 #include "Configuration.hpp"
 
+#include "checker/dd/applicationscheme/ApplicationScheme.hpp"
+#include "checker/dd/simulation/StateType.hpp"
+
 #include <nlohmann/json.hpp>
 
 namespace ec {
@@ -47,8 +50,8 @@ bool Configuration::onlySimulationCheckerConfigured() const noexcept {
          !execution.runAlternatingChecker && !execution.runZXChecker;
 }
 
-nlohmann::json Configuration::json() const {
-  nlohmann::json config{};
+nlohmann::basic_json<> Configuration::json() const {
+  nlohmann::basic_json<> config{};
   auto& exe = config["execution"];
   exe["tolerance"] = execution.numericalTolerance;
   exe["parallel"] = execution.parallel;

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -49,18 +49,18 @@ bool Configuration::onlySimulationCheckerConfigured() const noexcept {
 
 nlohmann::json Configuration::json() const {
   nlohmann::json config{};
-  auto&          exe = config["execution"];
-  exe["tolerance"]   = execution.numericalTolerance;
-  exe["parallel"]    = execution.parallel;
+  auto& exe = config["execution"];
+  exe["tolerance"] = execution.numericalTolerance;
+  exe["parallel"] = execution.parallel;
   if (execution.parallel) {
     exe["nthreads"] = execution.nthreads;
   } else {
     exe["nthreads"] = 1U;
   }
   exe["run_construction_checker"] = execution.runConstructionChecker;
-  exe["run_simulation_checker"]   = execution.runSimulationChecker;
-  exe["run_alternating_checker"]  = execution.runAlternatingChecker;
-  exe["run_zx_checker"]           = execution.runZXChecker;
+  exe["run_simulation_checker"] = execution.runSimulationChecker;
+  exe["run_alternating_checker"] = execution.runAlternatingChecker;
+  exe["run_zx_checker"] = execution.runZXChecker;
   if (execution.timeout > 0.) {
     exe["timeout"] = execution.timeout;
   }
@@ -71,7 +71,7 @@ nlohmann::json Configuration::json() const {
   opt["remove_diagonal_gates_before_measure"] =
       optimizations.removeDiagonalGatesBeforeMeasure;
   opt["transform_dynamic_circuit"] = optimizations.transformDynamicCircuit;
-  opt["reorder_operations"]        = optimizations.reorderOperations;
+  opt["reorder_operations"] = optimizations.reorderOperations;
   opt["backpropagate_output_permutation"] =
       optimizations.backpropagateOutputPermutation;
   opt["elide_permutations"] = optimizations.elidePermutations;
@@ -96,23 +96,23 @@ nlohmann::json Configuration::json() const {
     }
   }
 
-  auto& par                        = config["parameterized"];
-  par["tolerance"]                 = parameterized.parameterizedTol;
+  auto& par = config["parameterized"];
+  par["tolerance"] = parameterized.parameterizedTol;
   par["additional_instantiations"] = parameterized.nAdditionalInstantiations;
 
   if (execution.runConstructionChecker || execution.runAlternatingChecker) {
-    auto& fun                        = config["functionality"];
-    fun["trace_threshold"]           = functionality.traceThreshold;
+    auto& fun = config["functionality"];
+    fun["trace_threshold"] = functionality.traceThreshold;
     fun["check_partial_equivalence"] = functionality.checkPartialEquivalence;
   }
 
   if (execution.runSimulationChecker) {
-    auto& sim                          = config["simulation"];
-    sim["fidelity_threshold"]          = simulation.fidelityThreshold;
-    sim["max_sims"]                    = simulation.maxSims;
-    sim["state_type"]                  = ec::toString(simulation.stateType);
-    sim["seed"]                        = simulation.seed;
-    sim["store_counterexample_input"]  = simulation.storeCEXinput;
+    auto& sim = config["simulation"];
+    sim["fidelity_threshold"] = simulation.fidelityThreshold;
+    sim["max_sims"] = simulation.maxSims;
+    sim["state_type"] = ec::toString(simulation.stateType);
+    sim["seed"] = simulation.seed;
+    sim["store_counterexample_input"] = simulation.storeCEXinput;
     sim["store_counterexample_output"] = simulation.storeCEXoutput;
   }
 

--- a/src/EquivalenceCheckingManager.cpp
+++ b/src/EquivalenceCheckingManager.cpp
@@ -43,9 +43,9 @@ void decrementLogicalQubitsInLayoutAboveIndex(
 }
 
 void EquivalenceCheckingManager::stripIdleQubits() {
-  auto& largerCircuit  = qc1.getNqubits() > qc2.getNqubits() ? qc1 : qc2;
+  auto& largerCircuit = qc1.getNqubits() > qc2.getNqubits() ? qc1 : qc2;
   auto& smallerCircuit = qc1.getNqubits() > qc2.getNqubits() ? qc2 : qc1;
-  auto  qubitDifference =
+  auto qubitDifference =
       largerCircuit.getNqubits() - smallerCircuit.getNqubits();
   auto largerCircuitLayoutCopy = largerCircuit.initialLayout;
 
@@ -191,7 +191,7 @@ void EquivalenceCheckingManager::setupAncillariesAndGarbage() {
   std::vector<std::pair<qc::Qubit, std::optional<qc::Qubit>>> removed{};
   removed.reserve(qubitDifference);
 
-  const auto        nqubits = largerCircuit.getNqubits();
+  const auto nqubits = largerCircuit.getNqubits();
   std::vector<bool> garbage(nqubits);
 
   for (std::size_t i = 0; i < qubitDifference; ++i) {
@@ -294,16 +294,16 @@ void EquivalenceCheckingManager::runOptimizationPasses() {
 void EquivalenceCheckingManager::run() {
   done = false;
 
-  results.name1              = qc1.getName();
-  results.name2              = qc2.getName();
-  results.numQubits1         = qc1.getNqubits();
-  results.numQubits2         = qc2.getNqubits();
+  results.name1 = qc1.getName();
+  results.name2 = qc2.getName();
+  results.numQubits1 = qc1.getNqubits();
+  results.numQubits2 = qc2.getNqubits();
   results.numMeasuredQubits1 = qc1.getNmeasuredQubits();
   results.numMeasuredQubits2 = qc2.getNmeasuredQubits();
-  results.numAncillae1       = qc1.getNancillae();
-  results.numAncillae2       = qc2.getNancillae();
-  results.numGates1          = qc1.getNops();
-  results.numGates2          = qc2.getNops();
+  results.numAncillae1 = qc1.getNancillae();
+  results.numAncillae2 = qc2.getNancillae();
+  results.numGates1 = qc1.getNops();
+  results.numGates2 = qc2.getNops();
 
   results.configuration = configuration;
 
@@ -319,7 +319,7 @@ void EquivalenceCheckingManager::run() {
 
   if (qc1.empty() && qc2.empty()) {
     results.equivalence = EquivalenceCriterion::Equivalent;
-    done                = true;
+    done = true;
     return;
   }
 
@@ -387,7 +387,7 @@ EquivalenceCheckingManager::EquivalenceCheckingManager(
       !DDAlternatingChecker::canHandle(this->qc1, this->qc2)) {
     std::clog << "[QCEC] Warning: alternating checker cannot handle the "
                  "circuits. Falling back to construction checker.\n";
-    this->configuration.execution.runAlternatingChecker  = false;
+    this->configuration.execution.runAlternatingChecker = false;
     this->configuration.execution.runConstructionChecker = true;
   }
 
@@ -398,7 +398,7 @@ EquivalenceCheckingManager::EquivalenceCheckingManager(
   // number of unique computational basis states
   if (configuration.execution.runSimulationChecker &&
       configuration.simulation.stateType == StateType::ComputationalBasis) {
-    const auto        nq           = this->qc1.getNqubitsWithoutAncillae();
+    const auto nq = this->qc1.getNqubitsWithoutAncillae();
     const std::size_t uniqueStates = 1ULL << nq;
     if (nq <= 63U && configuration.simulation.maxSims > uniqueStates) {
       this->configuration.simulation.maxSims = uniqueStates;
@@ -420,7 +420,7 @@ void EquivalenceCheckingManager::checkSequential() {
     timeoutThread = std::thread([this, timeout = std::chrono::duration<double>(
                                            configuration.execution.timeout)] {
       std::unique_lock doneLock(doneMutex);
-      const auto       finished =
+      const auto finished =
           doneCond.wait_for(doneLock, timeout, [this] { return done; });
       // if the thread has already finished within the timeout, nothing
       // has to be done
@@ -575,7 +575,7 @@ void EquivalenceCheckingManager::checkSequential() {
     }
   }
 
-  const auto end    = std::chrono::steady_clock::now();
+  const auto end = std::chrono::steady_clock::now();
   results.checkTime = std::chrono::duration<double>(end - start).count();
 
   // appropriately join the timeout thread, if it was launched
@@ -640,7 +640,7 @@ void EquivalenceCheckingManager::checkParallel() {
 
   // create a thread safe queue which is used to check for available results
   ThreadSafeQueue<std::size_t> queue{};
-  std::size_t                  id = 0U;
+  std::size_t id = 0U;
 
   // reserve space for the futures received from the async calls
   std::vector<std::future<void>> futures{};
@@ -699,7 +699,7 @@ void EquivalenceCheckingManager::checkParallel() {
 
     // in case non-equivalence has been shown, the execution can be stopped
     const auto* const checker = checkers.at(*completedID).get();
-    const auto        result  = checker->getEquivalence();
+    const auto result = checker->getEquivalence();
 
     if (result == EquivalenceCriterion::NoInformation) {
       if (dynamic_cast<const ZXEquivalenceChecker*>(checker) != nullptr) {
@@ -834,7 +834,7 @@ void EquivalenceCheckingManager::checkParallel() {
     }
   }
 
-  const auto end    = std::chrono::steady_clock::now();
+  const auto end = std::chrono::steady_clock::now();
   results.checkTime = std::chrono::duration<double>(end - start).count();
 
   // Futures are not explicitly waited for here, since the destructor of the
@@ -855,7 +855,7 @@ void EquivalenceCheckingManager::checkSymbolic() {
     timeoutThread = std::thread([this, timeout = std::chrono::duration<double>(
                                            configuration.execution.timeout)] {
       std::unique_lock doneLock(doneMutex);
-      auto             finished =
+      auto finished =
           doneCond.wait_for(doneLock, timeout, [this] { return done; });
       // if the thread has already finished within the timeout,
       // nothing has to be done
@@ -872,9 +872,9 @@ void EquivalenceCheckingManager::checkSymbolic() {
           std::make_unique<ZXEquivalenceChecker>(qc1, qc2, configuration));
       const auto& zxChecker = checkers.back();
       if (!done) {
-        const auto result   = zxChecker->run();
+        const auto result = zxChecker->run();
         results.equivalence = result;
-        done                = true;
+        done = true;
         doneCond.notify_one();
       }
     } else {
@@ -887,7 +887,7 @@ void EquivalenceCheckingManager::checkSymbolic() {
       return;
     }
   }
-  const auto end    = std::chrono::steady_clock::now();
+  const auto end = std::chrono::steady_clock::now();
   results.checkTime = std::chrono::duration<double>(end - start).count();
   // appropriately join the timeout thread, if it was launched
   if (timeoutThread.joinable()) {
@@ -938,25 +938,25 @@ void EquivalenceCheckingManager::elidePermutations() {
 nlohmann::json EquivalenceCheckingManager::Results::json() const {
   nlohmann::json res{};
 
-  auto& circuit1         = res["circuit1"];
-  circuit1["name"]       = name1;
+  auto& circuit1 = res["circuit1"];
+  circuit1["name"] = name1;
   circuit1["num_qubits"] = numQubits1;
-  circuit1["num_gates"]  = numGates1;
+  circuit1["num_gates"] = numGates1;
 
-  auto& circuit2         = res["circuit2"];
-  circuit2["name"]       = name2;
+  auto& circuit2 = res["circuit2"];
+  circuit2["name"] = name2;
   circuit2["num_qubits"] = numQubits2;
-  circuit2["num_gates"]  = numGates2;
+  circuit2["num_gates"] = numGates2;
 
   res["configuration"] = configuration.json();
 
   res["preprocessing_time"] = preprocessingTime;
-  res["check_time"]         = checkTime;
-  res["equivalence"]        = ec::toString(equivalence);
+  res["check_time"] = checkTime;
+  res["equivalence"] = ec::toString(equivalence);
 
   if (startedSimulations > 0) {
-    auto& sim        = res["simulations"];
-    sim["started"]   = startedSimulations;
+    auto& sim = res["simulations"];
+    sim["started"] = startedSimulations;
     sim["performed"] = performedSimulations;
 
     if (!cexInput.empty() || !cexOutput1.empty() || !cexOutput2.empty()) {
@@ -972,7 +972,7 @@ nlohmann::json EquivalenceCheckingManager::Results::json() const {
       }
     }
   }
-  auto& par                       = res["parameterized"];
+  auto& par = res["parameterized"];
   par["performed_instantiations"] = performedInstantiations;
 
   res["checkers"] = checkerResults;

--- a/src/EquivalenceCheckingManager.cpp
+++ b/src/EquivalenceCheckingManager.cpp
@@ -10,6 +10,7 @@
 #include "EquivalenceCriterion.hpp"
 #include "Permutation.hpp"
 #include "QuantumComputation.hpp"
+#include "ThreadSafeQueue.hpp"
 #include "checker/dd/DDAlternatingChecker.hpp"
 #include "checker/dd/DDConstructionChecker.hpp"
 #include "checker/dd/DDSimulationChecker.hpp"
@@ -21,11 +22,13 @@
 #include <cassert>
 #include <chrono>
 #include <cstddef>
+#include <future>
 #include <iostream>
 #include <memory>
 #include <mutex>
+#include <nlohmann/json.hpp>
 #include <optional>
-#include <string>
+#include <stdexcept>
 #include <thread>
 #include <utility>
 #include <vector>
@@ -336,7 +339,7 @@ void EquivalenceCheckingManager::run() {
   }
 
   for (const auto& checker : checkers) {
-    nlohmann::json j{};
+    nlohmann::basic_json j{};
     checker->json(j);
     results.checkerResults.emplace_back(j);
   }
@@ -881,7 +884,7 @@ void EquivalenceCheckingManager::checkSymbolic() {
       std::clog << "Checking symbolic circuits requires transformation "
                    "to ZX-diagram but one of the circuits contains "
                    "operations not supported by this checker! Exiting!"
-                << std::endl;
+                << '\n';
       checkers.clear();
       results.equivalence = EquivalenceCriterion::NoInformation;
       return;

--- a/src/checker/EquivalenceChecker.cpp
+++ b/src/checker/EquivalenceChecker.cpp
@@ -5,10 +5,14 @@
 
 #include "checker/EquivalenceChecker.hpp"
 
+#include "EquivalenceCriterion.hpp"
+
+#include <nlohmann/json.hpp>
+
 // this function is mainly placed here in order to have an out-of-line
 // virtual method definition which avoids emitting the classe's vtable in
 // every translation unit.
-void ec::EquivalenceChecker::json(nlohmann::json& j) const noexcept {
+void ec::EquivalenceChecker::json(nlohmann::basic_json<>& j) const noexcept {
   j["equivalence"] = toString(equivalence);
   j["runtime"] = getRuntime();
 }

--- a/src/checker/EquivalenceChecker.cpp
+++ b/src/checker/EquivalenceChecker.cpp
@@ -10,5 +10,5 @@
 // every translation unit.
 void ec::EquivalenceChecker::json(nlohmann::json& j) const noexcept {
   j["equivalence"] = toString(equivalence);
-  j["runtime"]     = getRuntime();
+  j["runtime"] = getRuntime();
 }

--- a/src/checker/dd/DDAlternatingChecker.cpp
+++ b/src/checker/dd/DDAlternatingChecker.cpp
@@ -162,7 +162,7 @@ bool DDAlternatingChecker::canHandle(const qc::QuantumComputation& qc1,
   return true;
 }
 
-void DDAlternatingChecker::json(nlohmann::json& j) const noexcept {
+void DDAlternatingChecker::json(nlohmann::basic_json<>& j) const noexcept {
   DDEquivalenceChecker::json(j);
   j["checker"] = "decision_diagram_alternating";
 }

--- a/src/checker/dd/DDConstructionChecker.cpp
+++ b/src/checker/dd/DDConstructionChecker.cpp
@@ -12,7 +12,7 @@
 // this function is mainly placed here in order to have an out-of-line
 // virtual method definition which avoids emitting the classes' vtable in
 // every translation unit.
-void ec::DDConstructionChecker::json(nlohmann::json& j) const noexcept {
+void ec::DDConstructionChecker::json(nlohmann::basic_json<>& j) const noexcept {
   DDEquivalenceChecker::json(j);
   j["checker"] = "decision_diagram_construction";
 }

--- a/src/checker/dd/DDEquivalenceChecker.cpp
+++ b/src/checker/dd/DDEquivalenceChecker.cpp
@@ -51,7 +51,7 @@ DDEquivalenceChecker<DDType, Config>::equals(const DDType& e, const DDType& f) {
     // product trace(U V^-1) and comparing it to some threshold. in a similar
     // fashion, we can simply compare U V^-1 with the identity, which results in
     // a much simpler check that is not prone to overflow.
-    bool       isClose{};
+    bool isClose{};
     const bool eIsClose =
         dd->isCloseToIdentity(e, configuration.functionality.traceThreshold);
     const bool fIsClose =

--- a/src/checker/dd/DDEquivalenceChecker.cpp
+++ b/src/checker/dd/DDEquivalenceChecker.cpp
@@ -270,7 +270,7 @@ void DDEquivalenceChecker<DDType, Config>::initializeApplicationScheme(
 
 template <class DDType, class Config>
 void DDEquivalenceChecker<DDType, Config>::json(
-    nlohmann::json& j) const noexcept {
+    nlohmann::basic_json<>& j) const noexcept {
   EquivalenceChecker::json(j);
   j["max_nodes"] = maxActiveNodes;
 }

--- a/src/checker/dd/DDSimulationChecker.cpp
+++ b/src/checker/dd/DDSimulationChecker.cpp
@@ -50,7 +50,7 @@ void DDSimulationChecker::setRandomInitialState(StateGenerator& generator) {
       generator.generateRandomState(*dd, nqubits, nancillary, stateType);
 }
 
-void DDSimulationChecker::json(nlohmann::json& j) const noexcept {
+void DDSimulationChecker::json(nlohmann::basic_json<>& j) const noexcept {
   DDEquivalenceChecker::json(j);
   j["checker"] = "decision_diagram_simulation";
 }

--- a/src/checker/dd/DDSimulationChecker.cpp
+++ b/src/checker/dd/DDSimulationChecker.cpp
@@ -19,7 +19,7 @@
 namespace ec {
 DDSimulationChecker::DDSimulationChecker(const qc::QuantumComputation& circ1,
                                          const qc::QuantumComputation& circ2,
-                                         Configuration                 config)
+                                         Configuration config)
     : DDEquivalenceChecker(circ1, circ2, std::move(config)) {
   initialState = dd->makeZeroState(nqubits);
   initializeApplicationScheme(configuration.application.simulationScheme);
@@ -44,7 +44,7 @@ EquivalenceCriterion DDSimulationChecker::checkEquivalence() {
 
 void DDSimulationChecker::setRandomInitialState(StateGenerator& generator) {
   const auto nancillary = nqubits - qc1->getNqubitsWithoutAncillae();
-  const auto stateType  = configuration.simulation.stateType;
+  const auto stateType = configuration.simulation.stateType;
 
   initialState =
       generator.generateRandomState(*dd, nqubits, nancillary, stateType);

--- a/src/checker/dd/applicationscheme/GateCostApplicationScheme.cpp
+++ b/src/checker/dd/applicationscheme/GateCostApplicationScheme.cpp
@@ -5,6 +5,10 @@
 
 #include "checker/dd/applicationscheme/GateCostApplicationScheme.hpp"
 
+#include "operations/OpType.hpp"
+
+#include <cstddef>
+
 namespace ec {
 [[nodiscard]] std::size_t
 legacyCostFunction(const GateCostLookupTableKeyType& key) noexcept {

--- a/src/checker/dd/simulation/StateGenerator.cpp
+++ b/src/checker/dd/simulation/StateGenerator.cpp
@@ -11,7 +11,7 @@ void StateGenerator::seedGenerator(const std::size_t s) {
   seed = s;
   if (seed == 0U) {
     std::array<std::mt19937_64::result_type, std::mt19937_64::state_size>
-                       randomData{};
+        randomData{};
     std::random_device rd;
     std::generate(std::begin(randomData), std::end(randomData), std::ref(rd));
     std::seed_seq seeds(std::begin(randomData), std::end(randomData));

--- a/src/checker/dd/simulation/StateGenerator.cpp
+++ b/src/checker/dd/simulation/StateGenerator.cpp
@@ -5,6 +5,12 @@
 
 #include "checker/dd/simulation/StateGenerator.hpp"
 
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <functional>
+#include <random>
+
 namespace ec {
 
 void StateGenerator::seedGenerator(const std::size_t s) {

--- a/src/checker/zx/ZXChecker.cpp
+++ b/src/checker/zx/ZXChecker.cpp
@@ -66,7 +66,7 @@ EquivalenceCriterion ZXEquivalenceChecker::run() {
         continue;
       }
 
-      const auto& in   = miter.getInput(i);
+      const auto& in = miter.getInput(i);
       const auto& edge = miter.incidentEdge(in, 0U);
 
       if (edge.type == zx::EdgeType::Hadamard) {
@@ -74,8 +74,8 @@ EquivalenceCriterion ZXEquivalenceChecker::run() {
         break;
       }
       const auto& out = edge.to;
-      const auto& q1  = miter.getVData(in);
-      const auto& q2  = miter.getVData(out);
+      const auto& q1 = miter.getVData(in);
+      const auto& q2 = miter.getVData(out);
       assert(q1.has_value());
       assert(q2.has_value());
       if (p1.at(static_cast<qc::Qubit>(q1->qubit)) !=
@@ -136,11 +136,11 @@ qc::Permutation complete(const qc::Permutation& p, const std::size_t n) {
 
   qc::Permutation pComp = p;
 
-  std::vector<bool>                     mappedTo(n, false);
+  std::vector<bool> mappedTo(n, false);
   std::unordered_map<std::size_t, bool> mappedFrom;
   for (const auto [k, v] : p) {
     mappedFrom[k] = true;
-    mappedTo[v]   = true;
+    mappedTo[v] = true;
   }
 
   // Map qubits greedily
@@ -153,8 +153,8 @@ qc::Permutation complete(const qc::Permutation& p, const std::size_t n) {
     for (std::size_t j = 0; j < n; ++j) {
       if (mappedFrom.find(j) == mappedFrom.end()) {
         pComp[static_cast<qc::Qubit>(j)] = static_cast<qc::Qubit>(i);
-        mappedTo[i]                      = true;
-        mappedFrom[j]                    = true;
+        mappedTo[i] = true;
+        mappedFrom[j] = true;
         break;
       }
     }

--- a/src/checker/zx/ZXChecker.cpp
+++ b/src/checker/zx/ZXChecker.cpp
@@ -5,17 +5,21 @@
 
 #include "checker/zx/ZXChecker.hpp"
 
+#include "Configuration.hpp"
 #include "Definitions.hpp"
+#include "EquivalenceCriterion.hpp"
 #include "QuantumComputation.hpp"
+#include "checker/EquivalenceChecker.hpp"
 #include "zx/FunctionalityConstruction.hpp"
-#include "zx/Simplify.hpp"
+#include "zx/Rules.hpp"
+#include "zx/ZXDefinitions.hpp"
 #include "zx/ZXDiagram.hpp"
 
 #include <cassert>
 #include <chrono>
 #include <cstddef>
-#include <optional>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace ec {

--- a/test/legacy/test_compilationflow.cpp
+++ b/test/legacy/test_compilationflow.cpp
@@ -14,7 +14,7 @@ protected:
   qc::QuantumComputation qcOriginal;
   qc::QuantumComputation qcTranspiled;
 
-  std::string testOriginalDir   = "./circuits/original/";
+  std::string testOriginalDir = "./circuits/original/";
   std::string testTranspiledDir = "./circuits/transpiled/";
 
   ec::Configuration configuration{};
@@ -23,9 +23,9 @@ protected:
     qcOriginal.import(testOriginalDir + GetParam() + ".real");
     qcTranspiled.import(testTranspiledDir + GetParam() + "_transpiled.qasm");
 
-    configuration.execution.runAlternatingChecker  = true;
+    configuration.execution.runAlternatingChecker = true;
     configuration.execution.runConstructionChecker = false;
-    configuration.execution.runSimulationChecker   = false;
+    configuration.execution.runSimulationChecker = false;
 
     configuration.application.alternatingScheme =
         ec::ApplicationSchemeType::GateCost;
@@ -63,7 +63,7 @@ TEST_P(CompilationFlowTest, EquivalenceCompilationFlowNoElidePermutations) {
 
 TEST_P(CompilationFlowTest, EquivalenceCompilationFlowParallel) {
   configuration.execution.runSimulationChecker = true;
-  configuration.execution.parallel             = true;
+  configuration.execution.parallel = true;
 
   ec::EquivalenceCheckingManager ecm(qcOriginal, qcTranspiled, configuration);
   ecm.run();

--- a/test/legacy/test_compilationflow.cpp
+++ b/test/legacy/test_compilationflow.cpp
@@ -3,10 +3,15 @@
 // See README.md or go to https://github.com/cda-tum/qcec for more information.
 //
 
+#include "Configuration.hpp"
 #include "EquivalenceCheckingManager.hpp"
+#include "QuantumComputation.hpp"
+#include "checker/dd/applicationscheme/ApplicationScheme.hpp"
+#include "checker/dd/applicationscheme/GateCostApplicationScheme.hpp"
 
-#include "gtest/gtest.h"
-#include <functional>
+#include <algorithm>
+#include <gtest/gtest.h>
+#include <iostream>
 #include <string>
 
 class CompilationFlowTest : public testing::TestWithParam<std::string> {

--- a/test/legacy/test_functionality.cpp
+++ b/test/legacy/test_functionality.cpp
@@ -13,20 +13,20 @@ class FunctionalityTest : public testing::TestWithParam<std::string> {
 protected:
   qc::QuantumComputation qcOriginal;
   qc::QuantumComputation qcAlternative;
-  ec::Configuration      config{};
+  ec::Configuration config{};
 
-  std::string testOriginal       = "./circuits/test/test.real";
+  std::string testOriginal = "./circuits/test/test.real";
   std::string testAlternativeDir = "./circuits/test/";
 
   void SetUp() override {
     qcOriginal.import(testOriginal);
 
-    config.execution.parallel               = false;
+    config.execution.parallel = false;
     config.execution.runConstructionChecker = false;
-    config.execution.runAlternatingChecker  = false;
-    config.execution.runSimulationChecker   = false;
-    config.execution.runZXChecker           = false;
-    config.simulation.maxSims               = 16;
+    config.execution.runAlternatingChecker = false;
+    config.execution.runSimulationChecker = false;
+    config.execution.runZXChecker = false;
+    config.simulation.maxSims = 16;
     config.application.constructionScheme =
         ec::ApplicationSchemeType::Sequential;
     config.application.simulationScheme = ec::ApplicationSchemeType::Sequential;
@@ -76,7 +76,7 @@ TEST_P(FunctionalityTest, Lookahead) {
   qcAlternative.import(testAlternativeDir + "test_" + GetParam() + ".qasm");
 
   config.execution.runAlternatingChecker = true;
-  config.application.alternatingScheme   = ec::ApplicationSchemeType::Lookahead;
+  config.application.alternatingScheme = ec::ApplicationSchemeType::Lookahead;
 
   ec::EquivalenceCheckingManager ecm(qcOriginal, qcAlternative, config);
   ecm.run();
@@ -88,7 +88,7 @@ TEST_P(FunctionalityTest, Naive) {
   qcAlternative.import(testAlternativeDir + "test_" + GetParam() + ".qasm");
 
   config.execution.runAlternatingChecker = true;
-  config.application.alternatingScheme   = ec::ApplicationSchemeType::OneToOne;
+  config.application.alternatingScheme = ec::ApplicationSchemeType::OneToOne;
 
   ec::EquivalenceCheckingManager ecm(qcOriginal, qcAlternative, config);
   ecm.run();
@@ -100,8 +100,8 @@ TEST_P(FunctionalityTest, CompilationFlow) {
   qcAlternative.import(testAlternativeDir + "test_" + GetParam() + ".qasm");
 
   config.execution.runAlternatingChecker = true;
-  config.application.alternatingScheme   = ec::ApplicationSchemeType::GateCost;
-  config.application.costFunction        = ec::legacyCostFunction;
+  config.application.alternatingScheme = ec::ApplicationSchemeType::GateCost;
+  config.application.costFunction = ec::legacyCostFunction;
 
   ec::EquivalenceCheckingManager ecm(qcOriginal, qcAlternative, config);
   ecm.run();
@@ -124,7 +124,7 @@ TEST_P(FunctionalityTest, SimulationRandom1QBasis) {
   qcAlternative.import(testAlternativeDir + "test_" + GetParam() + ".qasm");
 
   config.execution.runSimulationChecker = true;
-  config.simulation.stateType           = ec::StateType::Random1QBasis;
+  config.simulation.stateType = ec::StateType::Random1QBasis;
 
   ec::EquivalenceCheckingManager ecm(qcOriginal, qcAlternative, config);
   ecm.run();
@@ -136,7 +136,7 @@ TEST_P(FunctionalityTest, SimulationStabilizer) {
   qcAlternative.import(testAlternativeDir + "test_" + GetParam() + ".qasm");
 
   config.execution.runSimulationChecker = true;
-  config.simulation.stateType           = ec::StateType::Stabilizer;
+  config.simulation.stateType = ec::StateType::Stabilizer;
 
   ec::EquivalenceCheckingManager ecm(qcOriginal, qcAlternative, config);
   ecm.run();
@@ -148,7 +148,7 @@ TEST_P(FunctionalityTest, SimulationParallel) {
   qcAlternative.import(testAlternativeDir + "test_" + GetParam() + ".qasm");
 
   config.execution.runSimulationChecker = true;
-  config.execution.parallel             = true;
+  config.execution.parallel = true;
   config.execution.nthreads = std::thread::hardware_concurrency() + 1U;
   config.simulation.maxSims = std::thread::hardware_concurrency() + 1U;
 
@@ -171,7 +171,7 @@ TEST_F(FunctionalityTest, test2) {
   EXPECT_TRUE(ecm.getResults().consideredEquivalent());
 
   config.execution.runConstructionChecker = false;
-  config.execution.runAlternatingChecker  = true;
+  config.execution.runAlternatingChecker = true;
   config.application.alternatingScheme =
       ec::ApplicationSchemeType::Proportional;
 
@@ -195,7 +195,7 @@ TEST_F(FunctionalityTest, test2) {
   EXPECT_TRUE(ecm4.getResults().consideredEquivalent());
 
   config.application.alternatingScheme = ec::ApplicationSchemeType::GateCost;
-  config.application.costFunction      = ec::legacyCostFunction;
+  config.application.costFunction = ec::legacyCostFunction;
 
   ec::EquivalenceCheckingManager ecm5(qcOriginal, qcAlternative, config);
   ecm5.run();

--- a/test/legacy/test_functionality.cpp
+++ b/test/legacy/test_functionality.cpp
@@ -3,11 +3,18 @@
 // See README.md or go to https://github.com/cda-tum/qcec for more information.
 //
 
+#include "Configuration.hpp"
 #include "EquivalenceCheckingManager.hpp"
+#include "QuantumComputation.hpp"
+#include "checker/dd/applicationscheme/ApplicationScheme.hpp"
+#include "checker/dd/applicationscheme/GateCostApplicationScheme.hpp"
+#include "checker/dd/simulation/StateType.hpp"
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <iostream>
+#include <sstream>
 #include <string>
+#include <thread>
 
 class FunctionalityTest : public testing::TestWithParam<std::string> {
 protected:

--- a/test/legacy/test_general.cpp
+++ b/test/legacy/test_general.cpp
@@ -17,15 +17,15 @@ protected:
 };
 
 TEST_F(GeneralTest, DynamicCircuit) {
-  auto s   = qc::BitString(15U);
-  auto bv  = qc::BernsteinVazirani(s);
+  auto s = qc::BitString(15U);
+  auto bv = qc::BernsteinVazirani(s);
   auto dbv = qc::BernsteinVazirani(s, true);
 
   auto config = ec::Configuration{};
   EXPECT_THROW(ec::EquivalenceCheckingManager(bv, dbv, config),
                std::runtime_error);
 
-  config.optimizations.transformDynamicCircuit        = true;
+  config.optimizations.transformDynamicCircuit = true;
   config.optimizations.backpropagateOutputPermutation = true;
 
   auto ecm = ec::EquivalenceCheckingManager(bv, dbv, config);
@@ -77,7 +77,7 @@ TEST_F(GeneralTest, RemoveDiagonalGatesBeforeMeasure) {
 
   // if configured to remove diagonal gates before measurements, the circuits
   // are equivalent
-  auto config                                           = ec::Configuration{};
+  auto config = ec::Configuration{};
   config.optimizations.removeDiagonalGatesBeforeMeasure = true;
   auto ecm2 = ec::EquivalenceCheckingManager(qc1, qc2, config);
   ecm2.run();
@@ -91,11 +91,11 @@ TEST_F(GeneralTest, NothingToDo) {
   qc2.addQubitRegister(1U);
   qc2.x(0);
 
-  auto config                             = ec::Configuration{};
-  config.execution.runAlternatingChecker  = false;
-  config.execution.runSimulationChecker   = false;
+  auto config = ec::Configuration{};
+  config.execution.runAlternatingChecker = false;
+  config.execution.runSimulationChecker = false;
   config.execution.runConstructionChecker = false;
-  config.execution.runZXChecker           = false;
+  config.execution.runZXChecker = false;
 
   auto ecm = ec::EquivalenceCheckingManager(qc1, qc2, config);
   ecm.run();
@@ -142,10 +142,10 @@ TEST_F(GeneralTest, NoGateCancellation) {
   qc1.cx(1_pc, 0);
   qc2.x(0);
 
-  auto config                               = ec::Configuration{};
-  config.optimizations.reorderOperations    = false;
+  auto config = ec::Configuration{};
+  config.optimizations.reorderOperations = false;
   config.optimizations.fuseSingleQubitGates = false;
-  config.optimizations.reconstructSWAPs     = false;
+  config.optimizations.reconstructSWAPs = false;
   config.application.alternatingScheme = ec::ApplicationSchemeType::OneToOne;
 
   ec::EquivalenceCheckingManager ecm(qc1, qc2, config);

--- a/test/legacy/test_general.cpp
+++ b/test/legacy/test_general.cpp
@@ -3,12 +3,17 @@
 // See README.md or go to https://github.com/cda-tum/qcec for more information.
 //
 
+#include "Configuration.hpp"
+#include "Definitions.hpp"
 #include "EquivalenceCheckingManager.hpp"
+#include "EquivalenceCriterion.hpp"
+#include "QuantumComputation.hpp"
 #include "algorithms/BernsteinVazirani.hpp"
+#include "checker/dd/applicationscheme/ApplicationScheme.hpp"
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <iostream>
-#include <string>
+#include <stdexcept>
 
 class GeneralTest : public ::testing::Test {
 protected:
@@ -125,10 +130,10 @@ TEST_F(GeneralTest, NoGateCancellation) {
   qc2.x(0);
 
   // two-qubit gates that cannot be cancelled
-  qc1.cx(1_pc, 0);
-  qc2.cx(0_pc, 1);
-  qc1.cx(1_pc, 0);
-  qc2.cx(0_pc, 1);
+  qc1.cx(1, 0);
+  qc2.cx(0, 1);
+  qc1.cx(1, 0);
+  qc2.cx(0, 1);
 
   // gates with parameters that cannot be cancelled
   qc1.p(2.0, 0);
@@ -138,8 +143,8 @@ TEST_F(GeneralTest, NoGateCancellation) {
 
   // gates with different number of controls that cannot be cancelled
   qc1.x(0);
-  qc2.cx(1_pc, 0);
-  qc1.cx(1_pc, 0);
+  qc2.cx(1, 0);
+  qc1.cx(1, 0);
   qc2.x(0);
 
   auto config = ec::Configuration{};

--- a/test/legacy/test_journal.cpp
+++ b/test/legacy/test_journal.cpp
@@ -3,13 +3,25 @@
 // See README.md or go to https://github.com/cda-tum/qcec for more information.
 //
 
+#include "Configuration.hpp"
 #include "EquivalenceCheckingManager.hpp"
+#include "EquivalenceCriterion.hpp"
+#include "QuantumComputation.hpp"
+#include "checker/dd/applicationscheme/ApplicationScheme.hpp"
 
-#include "gtest/gtest.h"
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
 #include <functional>
+#include <gtest/gtest.h>
 #include <iostream>
+#include <iterator>
 #include <random>
+#include <set>
+#include <sstream>
 #include <string>
+#include <tuple>
 
 class JournalTestNonEQ
     : public testing::TestWithParam<std::tuple<std::string, std::uint16_t>> {
@@ -30,14 +42,14 @@ protected:
   std::size_t maxSims = 0U;
   double avgSims = 0.;
 
-  std::string transpiledFile{};
+  std::string transpiledFile;
 
   std::mt19937_64 mt;
   std::uniform_int_distribution<std::uint64_t> distribution;
   std::function<std::uint64_t()> rng;
 
   std::uint16_t gatesToRemove = 0U;
-  std::set<std::set<std::uint64_t>> alreadyRemoved{};
+  std::set<std::set<std::uint64_t>> alreadyRemoved;
 
   std::uint16_t successes = 0U;
 
@@ -176,7 +188,7 @@ TEST_P(JournalTestNonEQ, PowerOfSimulation) {
     ecm.run();
     auto results = ecm.getResults();
     std::cout << "[" << i << "] ";
-    std::cout << toString(results.equivalence) << std::endl;
+    std::cout << toString(results.equivalence) << '\n';
     addToStatistics(i, results.checkTime + results.preprocessingTime,
                     results.performedSimulations);
     if (results.equivalence == ec::EquivalenceCriterion::NotEquivalent) {
@@ -188,7 +200,7 @@ TEST_P(JournalTestNonEQ, PowerOfSimulation) {
             << tries << ";" << minSims << ";" << maxSims << ";" << avgSims
             << ";" << minTime << ";" << maxTime << ";" << avgTime << ";"
             << static_cast<double>(successes) / static_cast<double>(tries)
-            << ";" << std::endl;
+            << ";" << '\n';
 }
 
 TEST_P(JournalTestNonEQ, PowerOfSimulationParallel) {
@@ -230,7 +242,7 @@ TEST_P(JournalTestNonEQ, PowerOfSimulationParallel) {
     ecm.run();
     auto results = ecm.getResults();
     std::cout << "[" << i << "] ";
-    std::cout << toString(results.equivalence) << std::endl;
+    std::cout << toString(results.equivalence) << '\n';
     addToStatistics(i, results.checkTime + results.preprocessingTime,
                     results.performedSimulations);
     if (results.equivalence == ec::EquivalenceCriterion::NotEquivalent) {
@@ -242,7 +254,7 @@ TEST_P(JournalTestNonEQ, PowerOfSimulationParallel) {
             << tries << ";" << minSims << ";" << maxSims << ";" << avgSims
             << ";" << minTime << ";" << maxTime << ";" << avgTime << ";"
             << static_cast<double>(successes) / static_cast<double>(tries)
-            << ";" << std::endl;
+            << ";" << '\n';
 }
 
 class JournalTestEQ : public testing::TestWithParam<std::string> {
@@ -254,7 +266,7 @@ protected:
   std::string testOriginalDir = "./circuits/original/";
   std::string testTranspiledDir = "./circuits/transpiled/";
 
-  std::string transpiledFile{};
+  std::string transpiledFile;
 
   void SetUp() override {
     config.execution.parallel = false;

--- a/test/legacy/test_journal.cpp
+++ b/test/legacy/test_journal.cpp
@@ -16,33 +16,33 @@ class JournalTestNonEQ
 protected:
   qc::QuantumComputation qcOriginal;
   qc::QuantumComputation qcTranspiled;
-  ec::Configuration      config;
+  ec::Configuration config;
 
-  std::string testOriginalDir   = "./circuits/original/";
+  std::string testOriginalDir = "./circuits/original/";
   std::string testTranspiledDir = "./circuits/transpiled/";
 
   std::uint16_t tries = 10U;
 
-  double      minTime = 0.;
-  double      maxTime = 0.;
-  double      avgTime = 0.;
+  double minTime = 0.;
+  double maxTime = 0.;
+  double avgTime = 0.;
   std::size_t minSims = 0U;
   std::size_t maxSims = 0U;
-  double      avgSims = 0.;
+  double avgSims = 0.;
 
   std::string transpiledFile{};
 
-  std::mt19937_64                              mt;
+  std::mt19937_64 mt;
   std::uniform_int_distribution<std::uint64_t> distribution;
-  std::function<std::uint64_t()>               rng;
+  std::function<std::uint64_t()> rng;
 
-  std::uint16_t                     gatesToRemove = 0U;
+  std::uint16_t gatesToRemove = 0U;
   std::set<std::set<std::uint64_t>> alreadyRemoved{};
 
   std::uint16_t successes = 0U;
 
   static bool setExists(const std::set<std::set<std::uint64_t>>& all,
-                        const std::set<std::uint64_t>&           test) {
+                        const std::set<std::uint64_t>& test) {
     // first entry
     if (all.empty()) {
       return false;
@@ -70,13 +70,13 @@ protected:
     transpiledFile = ss.str();
 
     std::array<std::mt19937_64::result_type, std::mt19937_64::state_size>
-                       randomData{};
+        randomData{};
     std::random_device rd;
     std::generate(begin(randomData), end(randomData), [&]() { return rd(); });
     std::seed_seq seeds(begin(randomData), end(randomData));
     mt.seed(seeds);
     distribution = decltype(distribution)(0U, qcTranspiled.getNops() - 1U);
-    rng          = [this]() { return distribution(mt); };
+    rng = [this]() { return distribution(mt); };
 
     gatesToRemove = std::get<1>(GetParam());
 
@@ -129,7 +129,7 @@ INSTANTIATE_TEST_SUITE_P(
         testing::Range(static_cast<unsigned short>(1U),
                        static_cast<unsigned short>(4U), 2)),
     [](const testing::TestParamInfo<JournalTestNonEQ::ParamType>& inf) {
-      std::string          name          = std::get<0>(inf.param);
+      std::string name = std::get<0>(inf.param);
       const unsigned short gatesToRemove = std::get<1>(inf.param);
       std::replace(name.begin(), name.end(), '-', '_');
       std::stringstream ss{};
@@ -138,13 +138,13 @@ INSTANTIATE_TEST_SUITE_P(
     });
 
 TEST_P(JournalTestNonEQ, PowerOfSimulation) {
-  config.execution.runAlternatingChecker  = false;
+  config.execution.runAlternatingChecker = false;
   config.execution.runConstructionChecker = false;
-  config.execution.runSimulationChecker   = true;
-  config.execution.runZXChecker           = false;
-  config.execution.parallel               = false;
-  config.execution.timeout                = 60.;
-  config.simulation.maxSims               = 16U;
+  config.execution.runSimulationChecker = true;
+  config.execution.runZXChecker = false;
+  config.execution.parallel = false;
+  config.execution.timeout = 60.;
+  config.simulation.maxSims = 16U;
   config.application.simulationScheme = ec::ApplicationSchemeType::Sequential;
   config.functionality.checkPartialEquivalence = true;
 
@@ -192,13 +192,13 @@ TEST_P(JournalTestNonEQ, PowerOfSimulation) {
 }
 
 TEST_P(JournalTestNonEQ, PowerOfSimulationParallel) {
-  config.execution.runAlternatingChecker  = false;
+  config.execution.runAlternatingChecker = false;
   config.execution.runConstructionChecker = false;
-  config.execution.runZXChecker           = false;
-  config.execution.runSimulationChecker   = true;
-  config.execution.parallel               = true;
-  config.execution.timeout                = 60.;
-  config.simulation.maxSims               = 16U;
+  config.execution.runZXChecker = false;
+  config.execution.runSimulationChecker = true;
+  config.execution.parallel = true;
+  config.execution.timeout = 60.;
+  config.simulation.maxSims = 16U;
   config.application.simulationScheme = ec::ApplicationSchemeType::Sequential;
   config.functionality.checkPartialEquivalence = true;
 
@@ -249,22 +249,22 @@ class JournalTestEQ : public testing::TestWithParam<std::string> {
 protected:
   qc::QuantumComputation qcOriginal;
   qc::QuantumComputation qcTranspiled;
-  ec::Configuration      config{};
+  ec::Configuration config{};
 
-  std::string testOriginalDir   = "./circuits/original/";
+  std::string testOriginalDir = "./circuits/original/";
   std::string testTranspiledDir = "./circuits/transpiled/";
 
   std::string transpiledFile{};
 
   void SetUp() override {
-    config.execution.parallel               = false;
+    config.execution.parallel = false;
     config.execution.runConstructionChecker = false;
-    config.execution.runAlternatingChecker  = false;
-    config.execution.runZXChecker           = false;
-    config.execution.runSimulationChecker   = false;
-    config.simulation.maxSims               = 16;
+    config.execution.runAlternatingChecker = false;
+    config.execution.runZXChecker = false;
+    config.execution.runSimulationChecker = false;
+    config.simulation.maxSims = 16;
     config.application.simulationScheme = ec::ApplicationSchemeType::OneToOne;
-    config.execution.timeout            = 60.;
+    config.execution.timeout = 60.;
 
     std::stringstream ss{};
     ss << testTranspiledDir << GetParam() << "_transpiled.qasm";
@@ -305,7 +305,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(JournalTestEQ, EQReference) {
   config.execution.runConstructionChecker = true;
-  config.application.constructionScheme   = ec::ApplicationSchemeType::OneToOne;
+  config.application.constructionScheme = ec::ApplicationSchemeType::OneToOne;
 
   ec::EquivalenceCheckingManager ecm(qcOriginal, qcTranspiled, config);
   ecm.run();
@@ -315,7 +315,7 @@ TEST_P(JournalTestEQ, EQReference) {
 
 TEST_P(JournalTestEQ, EQNaive) {
   config.execution.runAlternatingChecker = true;
-  config.application.alternatingScheme   = ec::ApplicationSchemeType::OneToOne;
+  config.application.alternatingScheme = ec::ApplicationSchemeType::OneToOne;
 
   ec::EquivalenceCheckingManager ecm(qcOriginal, qcTranspiled, config);
   ecm.run();
@@ -336,7 +336,7 @@ TEST_P(JournalTestEQ, EQProportional) {
 
 TEST_P(JournalTestEQ, EQLookahead) {
   config.execution.runAlternatingChecker = true;
-  config.application.alternatingScheme   = ec::ApplicationSchemeType::Lookahead;
+  config.application.alternatingScheme = ec::ApplicationSchemeType::Lookahead;
 
   ec::EquivalenceCheckingManager ecm(qcOriginal, qcTranspiled, config);
   ecm.run();
@@ -354,7 +354,7 @@ TEST_P(JournalTestEQ, EQPowerOfSimulation) {
 }
 
 TEST_P(JournalTestEQ, EQReferenceParallel) {
-  config.execution.parallel               = true;
+  config.execution.parallel = true;
   config.execution.runConstructionChecker = true;
   config.execution.runSimulationChecker = true; // additionally run simulations
   config.application.constructionScheme = ec::ApplicationSchemeType::OneToOne;
@@ -366,9 +366,9 @@ TEST_P(JournalTestEQ, EQReferenceParallel) {
 }
 
 TEST_P(JournalTestEQ, EQNaiveParallel) {
-  config.execution.parallel              = true;
+  config.execution.parallel = true;
   config.execution.runAlternatingChecker = true;
-  config.application.alternatingScheme   = ec::ApplicationSchemeType::OneToOne;
+  config.application.alternatingScheme = ec::ApplicationSchemeType::OneToOne;
 
   ec::EquivalenceCheckingManager ecm(qcOriginal, qcTranspiled, config);
   ecm.run();
@@ -377,7 +377,7 @@ TEST_P(JournalTestEQ, EQNaiveParallel) {
 }
 
 TEST_P(JournalTestEQ, EQProportionalParallel) {
-  config.execution.parallel              = true;
+  config.execution.parallel = true;
   config.execution.runAlternatingChecker = true;
   config.application.alternatingScheme =
       ec::ApplicationSchemeType::Proportional;
@@ -389,9 +389,9 @@ TEST_P(JournalTestEQ, EQProportionalParallel) {
 }
 
 TEST_P(JournalTestEQ, EQLookaheadParallel) {
-  config.execution.parallel              = true;
+  config.execution.parallel = true;
   config.execution.runAlternatingChecker = true;
-  config.application.alternatingScheme   = ec::ApplicationSchemeType::Lookahead;
+  config.application.alternatingScheme = ec::ApplicationSchemeType::Lookahead;
 
   ec::EquivalenceCheckingManager ecm(qcOriginal, qcTranspiled, config);
   ecm.run();
@@ -400,7 +400,7 @@ TEST_P(JournalTestEQ, EQLookaheadParallel) {
 }
 
 TEST_P(JournalTestEQ, EQPowerOfSimulationParallel) {
-  config.execution.parallel             = true;
+  config.execution.parallel = true;
   config.execution.runSimulationChecker = true;
 
   ec::EquivalenceCheckingManager ecm(qcOriginal, qcTranspiled, config);

--- a/test/legacy/test_simulation.cpp
+++ b/test/legacy/test_simulation.cpp
@@ -3,9 +3,13 @@
 // See README.md or go to https://github.com/cda-tum/qcec for more information.
 //
 
+#include "Configuration.hpp"
 #include "EquivalenceCheckingManager.hpp"
+#include "QuantumComputation.hpp"
+#include "checker/dd/simulation/StateType.hpp"
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
+#include <iostream>
 
 class SimulationTest : public ::testing::Test {
 protected:

--- a/test/legacy/test_simulation.cpp
+++ b/test/legacy/test_simulation.cpp
@@ -11,18 +11,18 @@ class SimulationTest : public ::testing::Test {
 protected:
   qc::QuantumComputation qcOriginal;
   qc::QuantumComputation qcAlternative;
-  ec::Configuration      config{};
+  ec::Configuration config{};
 
   void SetUp() override {
-    config.execution.runAlternatingChecker  = false;
+    config.execution.runAlternatingChecker = false;
     config.execution.runConstructionChecker = false;
-    config.execution.runSimulationChecker   = true;
-    config.execution.parallel               = false;
+    config.execution.runSimulationChecker = true;
+    config.execution.parallel = false;
 
-    config.simulation.maxSims        = 8U;
-    config.simulation.storeCEXinput  = true;
+    config.simulation.maxSims = 8U;
+    config.simulation.storeCEXinput = true;
     config.simulation.storeCEXoutput = true;
-    config.simulation.seed           = 12345U;
+    config.simulation.seed = 12345U;
   }
 };
 

--- a/test/test_dynamic_circuits.cpp
+++ b/test/test_dynamic_circuits.cpp
@@ -1,20 +1,30 @@
+#include "Configuration.hpp"
+#include "Definitions.hpp"
 #include "EquivalenceCheckingManager.hpp"
+#include "EquivalenceCriterion.hpp"
+#include "QuantumComputation.hpp"
 #include "algorithms/BernsteinVazirani.hpp"
 #include "algorithms/QFT.hpp"
 #include "algorithms/QPE.hpp"
+#include "dd/DDDefinitions.hpp"
+#include "dd/Package.hpp"
 
 #include <bitset>
+#include <cstddef>
+#include <cstdlib>
+#include <fstream>
 #include <gtest/gtest.h>
-#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <sstream>
 #include <string>
-#include <utility>
 
 class DynamicCircuitTestExactQPE : public testing::TestWithParam<std::size_t> {
 protected:
   std::size_t precision{};
   qc::fp theta{};
   std::size_t expectedResult{};
-  std::string expectedResultRepresentation{};
+  std::string expectedResultRepresentation;
   std::unique_ptr<qc::QuantumComputation> qpe;
   std::unique_ptr<qc::QuantumComputation> iqpe;
   std::unique_ptr<dd::Package<>> dd;
@@ -104,9 +114,9 @@ protected:
   std::size_t precision{};
   dd::fp theta{};
   std::size_t expectedResult{};
-  std::string expectedResultRepresentation{};
+  std::string expectedResultRepresentation;
   std::size_t secondExpectedResult{};
-  std::string secondExpectedResultRepresentation{};
+  std::string secondExpectedResultRepresentation;
   std::unique_ptr<qc::QuantumComputation> qpe;
   std::unique_ptr<qc::QuantumComputation> iqpe;
   std::unique_ptr<dd::Package<>> dd;

--- a/test/test_dynamic_circuits.cpp
+++ b/test/test_dynamic_circuits.cpp
@@ -11,14 +11,14 @@
 
 class DynamicCircuitTestExactQPE : public testing::TestWithParam<std::size_t> {
 protected:
-  std::size_t                             precision{};
-  qc::fp                                  theta{};
-  std::size_t                             expectedResult{};
-  std::string                             expectedResultRepresentation{};
+  std::size_t precision{};
+  qc::fp theta{};
+  std::size_t expectedResult{};
+  std::string expectedResultRepresentation{};
   std::unique_ptr<qc::QuantumComputation> qpe;
   std::unique_ptr<qc::QuantumComputation> iqpe;
-  std::unique_ptr<dd::Package<>>          dd;
-  std::ofstream                           ofs;
+  std::unique_ptr<dd::Package<>> dd;
+  std::ofstream ofs;
 
   ec::Configuration config{};
 
@@ -31,7 +31,7 @@ protected:
     qpe = std::make_unique<qc::QPE>(precision);
 
     const auto lambda = dynamic_cast<qc::QPE*>(qpe.get())->lambda;
-    iqpe              = std::make_unique<qc::QPE>(lambda, precision, true);
+    iqpe = std::make_unique<qc::QPE>(lambda, precision, true);
 
     std::cout << "Estimating lambda = " << lambda << "π up to " << precision
               << "-bit precision.\n";
@@ -40,8 +40,8 @@ protected:
 
     std::cout << "Expected theta=" << theta << "\n";
     std::bitset<64> binaryExpansion{};
-    dd::fp          expansion = theta * 2;
-    std::size_t     index     = 0;
+    dd::fp expansion = theta * 2;
+    std::size_t index = 0;
     while (std::abs(expansion) > 1e-8) {
       if (expansion >= 1.) {
         binaryExpansion.set(index);
@@ -72,7 +72,7 @@ protected:
     std::cout << "The expected output state is |"
               << expectedResultRepresentation << ">.\n";
 
-    config.optimizations.transformDynamicCircuit        = true;
+    config.optimizations.transformDynamicCircuit = true;
     config.optimizations.backpropagateOutputPermutation = true;
   }
 };
@@ -81,7 +81,7 @@ INSTANTIATE_TEST_SUITE_P(
     Eval, DynamicCircuitTestExactQPE, testing::Range<std::size_t>(1U, 64U, 5U),
     [](const testing::TestParamInfo<DynamicCircuitTestExactQPE::ParamType>&
            inf) {
-      const auto        nqubits = inf.param;
+      const auto nqubits = inf.param;
       std::stringstream ss{};
       ss << nqubits;
       if (nqubits == 1) {
@@ -101,16 +101,16 @@ TEST_P(DynamicCircuitTestExactQPE, UnitaryEquivalence) {
 class DynamicCircuitTestInexactQPE
     : public testing::TestWithParam<std::size_t> {
 protected:
-  std::size_t                             precision{};
-  dd::fp                                  theta{};
-  std::size_t                             expectedResult{};
-  std::string                             expectedResultRepresentation{};
-  std::size_t                             secondExpectedResult{};
-  std::string                             secondExpectedResultRepresentation{};
+  std::size_t precision{};
+  dd::fp theta{};
+  std::size_t expectedResult{};
+  std::string expectedResultRepresentation{};
+  std::size_t secondExpectedResult{};
+  std::string secondExpectedResultRepresentation{};
   std::unique_ptr<qc::QuantumComputation> qpe;
   std::unique_ptr<qc::QuantumComputation> iqpe;
-  std::unique_ptr<dd::Package<>>          dd;
-  std::ofstream                           ofs;
+  std::unique_ptr<dd::Package<>> dd;
+  std::ofstream ofs;
 
   ec::Configuration config{};
 
@@ -123,7 +123,7 @@ protected:
     qpe = std::make_unique<qc::QPE>(precision, false);
 
     const auto lambda = dynamic_cast<qc::QPE*>(qpe.get())->lambda;
-    iqpe              = std::make_unique<qc::QPE>(lambda, precision, true);
+    iqpe = std::make_unique<qc::QPE>(lambda, precision, true);
 
     std::cout << "Estimating lambda = " << lambda << "π up to " << precision
               << "-bit precision.\n";
@@ -132,8 +132,8 @@ protected:
 
     std::cout << "Expected theta=" << theta << "\n";
     std::bitset<64> binaryExpansion{};
-    dd::fp          expansion = theta * 2;
-    std::size_t     index     = 0;
+    dd::fp expansion = theta * 2;
+    std::size_t index = 0;
     while (std::abs(expansion) > 1e-8) {
       if (expansion >= 1.) {
         binaryExpansion.set(index);
@@ -176,7 +176,7 @@ protected:
               << expectedResultRepresentation << "> and |"
               << secondExpectedResultRepresentation << ">.\n";
 
-    config.optimizations.transformDynamicCircuit        = true;
+    config.optimizations.transformDynamicCircuit = true;
     config.optimizations.backpropagateOutputPermutation = true;
   }
 };
@@ -185,7 +185,7 @@ INSTANTIATE_TEST_SUITE_P(Eval, DynamicCircuitTestInexactQPE,
                          testing::Range<std::size_t>(1U, 15U, 3U),
                          [](const testing::TestParamInfo<
                              DynamicCircuitTestInexactQPE::ParamType>& inf) {
-                           const auto        nqubits = inf.param;
+                           const auto nqubits = inf.param;
                            std::stringstream ss{};
                            ss << nqubits;
                            if (nqubits == 1) {
@@ -204,11 +204,11 @@ TEST_P(DynamicCircuitTestInexactQPE, UnitaryEquivalence) {
 
 class DynamicCircuitTestBV : public testing::TestWithParam<std::size_t> {
 protected:
-  std::size_t                             bitwidth{};
+  std::size_t bitwidth{};
   std::unique_ptr<qc::QuantumComputation> bv;
   std::unique_ptr<qc::QuantumComputation> dbv;
-  std::unique_ptr<dd::Package<>>          dd;
-  std::ofstream                           ofs;
+  std::unique_ptr<dd::Package<>> dd;
+  std::ofstream ofs;
 
   ec::Configuration config{};
 
@@ -221,14 +221,14 @@ protected:
     bv = std::make_unique<qc::BernsteinVazirani>(bitwidth);
 
     const auto s = dynamic_cast<qc::BernsteinVazirani*>(bv.get())->s;
-    dbv          = std::make_unique<qc::BernsteinVazirani>(s, bitwidth, true);
+    dbv = std::make_unique<qc::BernsteinVazirani>(s, bitwidth, true);
 
     const auto expected =
         dynamic_cast<qc::BernsteinVazirani*>(bv.get())->expected;
     std::cout << "Hidden bitstring: " << expected << " (" << bitwidth
               << " qubits)\n";
 
-    config.optimizations.transformDynamicCircuit        = true;
+    config.optimizations.transformDynamicCircuit = true;
     config.optimizations.backpropagateOutputPermutation = true;
   }
 };
@@ -236,7 +236,7 @@ protected:
 INSTANTIATE_TEST_SUITE_P(
     Eval, DynamicCircuitTestBV, testing::Range<std::size_t>(1U, 64U, 5U),
     [](const testing::TestParamInfo<DynamicCircuitTestBV::ParamType>& inf) {
-      const auto        nqubits = inf.param;
+      const auto nqubits = inf.param;
       std::stringstream ss{};
       ss << nqubits;
       if (nqubits == 1) {
@@ -255,11 +255,11 @@ TEST_P(DynamicCircuitTestBV, UnitaryEquivalence) {
 
 class DynamicCircuitTestQFT : public testing::TestWithParam<std::size_t> {
 protected:
-  std::size_t                             precision{};
+  std::size_t precision{};
   std::unique_ptr<qc::QuantumComputation> qft;
   std::unique_ptr<qc::QuantumComputation> dqft;
-  std::unique_ptr<dd::Package<>>          dd;
-  std::ofstream                           ofs;
+  std::unique_ptr<dd::Package<>> dd;
+  std::ofstream ofs;
 
   ec::Configuration config{};
 
@@ -273,7 +273,7 @@ protected:
 
     dqft = std::make_unique<qc::QFT>(precision, true, true);
 
-    config.optimizations.transformDynamicCircuit        = true;
+    config.optimizations.transformDynamicCircuit = true;
     config.optimizations.backpropagateOutputPermutation = true;
   }
 };
@@ -281,7 +281,7 @@ protected:
 INSTANTIATE_TEST_SUITE_P(
     Eval, DynamicCircuitTestQFT, testing::Range<std::size_t>(1U, 65U, 5U),
     [](const testing::TestParamInfo<DynamicCircuitTestQFT::ParamType>& inf) {
-      const auto        nqubits = inf.param;
+      const auto nqubits = inf.param;
       std::stringstream ss{};
       ss << nqubits;
       if (nqubits == 1) {

--- a/test/test_equality.cpp
+++ b/test/test_equality.cpp
@@ -4,11 +4,16 @@
 //
 
 #include "EquivalenceCheckingManager.hpp"
-#include "checker/dd/applicationscheme/GateCostApplicationScheme.hpp"
+#include "EquivalenceCriterion.hpp"
+#include "checker/dd/applicationscheme/ApplicationScheme.hpp"
+#include "dd/DDDefinitions.hpp"
+#include "operations/Control.hpp"
 
-#include "gtest/gtest.h"
-#include <functional>
-#include <sstream>
+#include <cstddef>
+#include <gtest/gtest.h>
+#include <iostream>
+#include <optional>
+#include <stdexcept>
 
 class EqualityTest : public testing::Test {
   void SetUp() override {

--- a/test/test_equality.cpp
+++ b/test/test_equality.cpp
@@ -15,17 +15,17 @@ class EqualityTest : public testing::Test {
     qc1 = qc::QuantumComputation(nqubits);
     qc2 = qc::QuantumComputation(nqubits);
 
-    config.execution.runSimulationChecker   = false;
-    config.execution.runAlternatingChecker  = false;
+    config.execution.runSimulationChecker = false;
+    config.execution.runAlternatingChecker = false;
     config.execution.runConstructionChecker = false;
-    config.execution.runZXChecker           = false;
+    config.execution.runZXChecker = false;
   }
 
 protected:
-  std::size_t            nqubits = 1U;
+  std::size_t nqubits = 1U;
   qc::QuantumComputation qc1;
   qc::QuantumComputation qc2;
-  ec::Configuration      config{};
+  ec::Configuration config{};
 };
 
 TEST_F(EqualityTest, GlobalPhase) {
@@ -59,14 +59,14 @@ TEST_F(EqualityTest, GlobalPhaseSimulation) {
   qc2.z(0);
   qc2.x(0);
 
-  config.execution.runAlternatingChecker  = false;
+  config.execution.runAlternatingChecker = false;
   config.execution.runConstructionChecker = false;
-  config.execution.runZXChecker           = false;
-  config.execution.runSimulationChecker   = true;
-  config.execution.parallel               = false;
+  config.execution.runZXChecker = false;
+  config.execution.runSimulationChecker = true;
+  config.execution.parallel = false;
   ec::EquivalenceCheckingManager ecm(qc1, qc2, config);
   ecm.run();
-  const auto json       = ecm.getResults().json();
+  const auto json = ecm.getResults().json();
   const auto simChecker = json["checkers"].front();
   EXPECT_EQ(simChecker["equivalence"], "equivalent_up_to_phase");
 }
@@ -77,7 +77,7 @@ TEST_F(EqualityTest, CloseButNotEqualAlternating) {
   qc2.x(0);
   qc2.p(dd::PI / 1024., 0);
 
-  config.functionality.traceThreshold    = 1e-2;
+  config.functionality.traceThreshold = 1e-2;
   config.execution.runAlternatingChecker = true;
   ec::EquivalenceCheckingManager ecm(qc1, qc2, config);
   ecm.run();
@@ -91,7 +91,7 @@ TEST_F(EqualityTest, CloseButNotEqualConstruction) {
   qc2.x(0);
   qc2.p(dd::PI / 1024., 0);
 
-  config.functionality.traceThreshold     = 1e-2;
+  config.functionality.traceThreshold = 1e-2;
   config.execution.runConstructionChecker = true;
   ec::EquivalenceCheckingManager ecm(qc1, qc2, config);
   ecm.run();
@@ -110,7 +110,7 @@ TEST_F(EqualityTest, CloseButNotEqualAlternatingGlobalPhase) {
   qc2.z(0);
   qc2.x(0);
 
-  config.functionality.traceThreshold    = 1e-2;
+  config.functionality.traceThreshold = 1e-2;
   config.execution.runAlternatingChecker = true;
   ec::EquivalenceCheckingManager ecm(qc1, qc2, config);
   ecm.run();
@@ -125,7 +125,7 @@ TEST_F(EqualityTest, CloseButNotEqualSimulation) {
   qc2.h(0);
   qc2.p(dd::PI / 1024., 0);
 
-  config.simulation.fidelityThreshold   = 1e-2;
+  config.simulation.fidelityThreshold = 1e-2;
   config.execution.runSimulationChecker = true;
   ec::EquivalenceCheckingManager ecm(qc1, qc2, config);
   ecm.run();
@@ -141,7 +141,7 @@ TEST_F(EqualityTest, SimulationMoreThan64Qubits) {
   for (auto i = 0U; i < 64U; ++i) {
     qc1.cx(0_pc, i + 1);
   }
-  qc2                                   = qc1;
+  qc2 = qc1;
   config.execution.runSimulationChecker = true;
   ec::EquivalenceCheckingManager ecm(qc1, qc2, config);
   ecm.run();
@@ -193,11 +193,11 @@ TEST_F(EqualityTest, AutomaticSwitchToConstructionChecker) {
 TEST_F(EqualityTest, ExceptionInParallelThread) {
   qc1.x(0);
 
-  config                                  = ec::Configuration{};
-  config.execution.runAlternatingChecker  = false;
+  config = ec::Configuration{};
+  config.execution.runAlternatingChecker = false;
   config.execution.runConstructionChecker = false;
-  config.execution.runSimulationChecker   = true;
-  config.execution.runZXChecker           = false;
+  config.execution.runSimulationChecker = true;
+  config.execution.runZXChecker = false;
   config.application.simulationScheme = ec::ApplicationSchemeType::Lookahead;
 
   ec::EquivalenceCheckingManager ecm(qc1, qc1, config);
@@ -288,7 +288,7 @@ TEST_F(EqualityTest, onlySingleTask) {
   qc1.h(0);
   qc2.h(0);
   config.execution.runSimulationChecker = true;
-  config.simulation.maxSims             = 1U;
+  config.simulation.maxSims = 1U;
   ec::EquivalenceCheckingManager ecm(qc1, qc2, config);
   ecm.run();
   EXPECT_TRUE(ecm.getConfiguration().onlySingleTask());
@@ -389,7 +389,7 @@ TEST_F(EqualityTest, EqualDueToNoSeparateIdleQubitStripping) {
   qc2.initializeIOMapping();
 
   config.execution.runConstructionChecker = true;
-  config.optimizations.elidePermutations  = false;
+  config.optimizations.elidePermutations = false;
   ec::EquivalenceCheckingManager ecm(qc1, qc2, config);
   ecm.run();
   EXPECT_EQ(ecm.equivalence(), ec::EquivalenceCriterion::Equivalent);
@@ -403,7 +403,7 @@ TEST_F(EqualityTest,
        StripIdleQubitPresentInBothCircuitsWithDifferentInitialLayout) {
   // Test that idle qubits are removed correctly even if the initial layout is
   // different
-  qc1                  = qc::QuantumComputation(3, 2);
+  qc1 = qc::QuantumComputation(3, 2);
   qc1.initialLayout[0] = 0;
   qc1.initialLayout[1] = 2;
   qc1.initialLayout[2] = 1;
@@ -465,7 +465,7 @@ TEST_F(EqualityTest, StripIdleQubitLogicalOnlyInOnePhysicalInBothCircuits) {
   qc1.measure(1, 1);
   qc1.initializeIOMapping();
 
-  qc2                  = qc::QuantumComputation(3, 2);
+  qc2 = qc::QuantumComputation(3, 2);
   qc2.initialLayout[0] = 0;
   qc2.initialLayout[1] = 2;
   qc2.initialLayout[2] = 1;
@@ -494,13 +494,13 @@ TEST_F(EqualityTest, StripIdleQubitOutputPermutationDifferent) {
   qc1.swap(0, 1);
   qc1.initializeIOMapping();
 
-  qc2                      = qc::QuantumComputation(2);
+  qc2 = qc::QuantumComputation(2);
   qc2.outputPermutation[0] = 1;
   qc2.outputPermutation[1] = 0;
   qc2.initializeIOMapping();
 
   config.execution.runConstructionChecker = true;
-  config.optimizations.elidePermutations  = true;
+  config.optimizations.elidePermutations = true;
   ec::EquivalenceCheckingManager ecm(qc1, qc2, config);
   ecm.run();
   EXPECT_EQ(ecm.equivalence(), ec::EquivalenceCriterion::Equivalent);
@@ -518,9 +518,9 @@ TEST_F(EqualityTest, StripIdleQubitOutputPermutationEquivalent) {
   qc1 = qc::QuantumComputation(2);
   qc1.initializeIOMapping();
 
-  qc2                      = qc::QuantumComputation(2);
-  qc2.initialLayout[0]     = 1;
-  qc2.initialLayout[1]     = 0;
+  qc2 = qc::QuantumComputation(2);
+  qc2.initialLayout[0] = 1;
+  qc2.initialLayout[1] = 0;
   qc2.outputPermutation[0] = 1;
   qc2.outputPermutation[1] = 0;
   qc2.initializeIOMapping();
@@ -542,7 +542,7 @@ TEST_F(EqualityTest, StripQubitIdleInOneCircuitOnlyOutputPermutationDifferent) {
   qc1 = qc::QuantumComputation(1);
   qc1.initializeIOMapping();
 
-  qc2                      = qc::QuantumComputation(2);
+  qc2 = qc::QuantumComputation(2);
   qc2.outputPermutation[0] = 1;
   qc2.outputPermutation[1] = 0;
   qc2.initializeIOMapping();

--- a/test/test_gate_cost_application_scheme.cpp
+++ b/test/test_gate_cost_application_scheme.cpp
@@ -3,12 +3,20 @@
 // See README.md or go to https://github.com/cda-tum/qcec for more information.
 //
 
+#include "Configuration.hpp"
 #include "EquivalenceCheckingManager.hpp"
+#include "checker/dd/TaskManager.hpp"
+#include "checker/dd/applicationscheme/ApplicationScheme.hpp"
 #include "checker/dd/applicationscheme/GateCostApplicationScheme.hpp"
+#include "dd/Package.hpp"
+#include "dd/Package_fwd.hpp"
+#include "operations/Control.hpp"
 
-#include "gtest/gtest.h"
-#include <functional>
-#include <sstream>
+#include <cstddef>
+#include <fstream>
+#include <gtest/gtest.h>
+#include <iostream>
+#include <memory>
 #include <string>
 
 class GateCostApplicationSchemeTest : public testing::Test {

--- a/test/test_gate_cost_application_scheme.cpp
+++ b/test/test_gate_cost_application_scheme.cpp
@@ -18,16 +18,16 @@ class GateCostApplicationSchemeTest : public testing::Test {
   }
 
 protected:
-  std::size_t                    nqubits = 3U;
+  std::size_t nqubits = 3U;
   std::unique_ptr<dd::Package<>> dd;
-  qc::QuantumComputation         qc;
+  qc::QuantumComputation qc;
 };
 
 TEST_F(GateCostApplicationSchemeTest, SchemeFromProfile) {
   using namespace qc::literals;
 
   const std::string filename = "simple.profile";
-  std::ofstream     ofs(filename);
+  std::ofstream ofs(filename);
 
   // create a very simple profile that just specifies that a Toffoli corresponds
   // to 15 gates
@@ -47,7 +47,7 @@ TEST_F(GateCostApplicationSchemeTest, SchemeFromProfile) {
   EXPECT_EQ(right, 15U);
 
   ec::Configuration config{};
-  config.application.profile           = filename;
+  config.application.profile = filename;
   config.application.alternatingScheme = ec::ApplicationSchemeType::GateCost;
   ec::EquivalenceCheckingManager ecm(qc, qc, config);
   ecm.run();

--- a/test/test_partial_equivalence.cpp
+++ b/test/test_partial_equivalence.cpp
@@ -3,12 +3,25 @@
 // See README.md or go to https://github.com/cda-tum/qcec for more information.
 //
 
+#include "Definitions.hpp"
 #include "EquivalenceCheckingManager.hpp"
+#include "EquivalenceCriterion.hpp"
 #include "QuantumComputation.hpp"
+#include "dd/DDDefinitions.hpp"
+#include "operations/Control.hpp"
 #include "operations/OpType.hpp"
 #include "operations/StandardOperation.hpp"
 
 #include "gtest/gtest.h"
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <random>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace dd {
 
@@ -891,7 +904,7 @@ void partialEquivalencCheckingBenchmarks(const qc::Qubit minN,
     double totalTime{0};
     std::size_t totalGates{0};
     for (size_t k = 0; k < reps; k++) {
-      qc::Qubit d{0};
+      qc::Qubit d{};
       if (addAncilla) {
         std::uniform_int_distribution<qc::Qubit> nrDataQubits(1, n);
         d = nrDataQubits(gen);

--- a/test/test_partial_equivalence.cpp
+++ b/test/test_partial_equivalence.cpp
@@ -26,19 +26,19 @@ const std::vector<std::vector<OpType>> PRE_GENERATED_CIRCUITS_SIZE_2_2{
 
 void addPreGeneratedCircuits(QuantumComputation& circuit1,
                              QuantumComputation& circuit2,
-                             const qc::Qubit     groupBeginIndex,
-                             const qc::Qubit     groupSize) {
-  const auto& circuits1       = groupSize == 1 ? PRE_GENERATED_CIRCUITS_SIZE_1_1
-                                               : PRE_GENERATED_CIRCUITS_SIZE_2_1;
-  const auto& circuits2       = groupSize == 1 ? PRE_GENERATED_CIRCUITS_SIZE_1_2
-                                               : PRE_GENERATED_CIRCUITS_SIZE_2_2;
-  const auto  nrCircuits      = circuits1.size();
-  auto        randomGenerator = circuit1.getGenerator();
+                             const qc::Qubit groupBeginIndex,
+                             const qc::Qubit groupSize) {
+  const auto& circuits1 = groupSize == 1 ? PRE_GENERATED_CIRCUITS_SIZE_1_1
+                                         : PRE_GENERATED_CIRCUITS_SIZE_2_1;
+  const auto& circuits2 = groupSize == 1 ? PRE_GENERATED_CIRCUITS_SIZE_1_2
+                                         : PRE_GENERATED_CIRCUITS_SIZE_2_2;
+  const auto nrCircuits = circuits1.size();
+  auto randomGenerator = circuit1.getGenerator();
   std::uniform_int_distribution<size_t> randomDistribution(0, nrCircuits - 1);
 
   const auto randomIndex = randomDistribution(randomGenerator);
-  const auto x1          = circuits1[randomIndex];
-  const auto x2          = circuits2[randomIndex];
+  const auto x1 = circuits1[randomIndex];
+  const auto x2 = circuits2[randomIndex];
   for (auto gateType : x1) {
     if (gateType == X) { // add CNOT
       circuit1.emplace_back<StandardOperation>(groupBeginIndex,
@@ -78,9 +78,9 @@ void addDecomposedCcxGate(QuantumComputation& circuit, const Controls& controls,
   circuit.cx(control2, control1);
 }
 
-void addStandardOperationToCircuit(QuantumComputation&      circuit,
+void addStandardOperationToCircuit(QuantumComputation& circuit,
                                    const StandardOperation& op,
-                                   const bool               decomposeCcx) {
+                                   const bool decomposeCcx) {
   if (op.getType() == X && decomposeCcx && op.getControls().size() == 2) {
     // decompose toffoli gate
     addDecomposedCcxGate(circuit, op.getControls(), op.getTargets()[0]);
@@ -196,7 +196,7 @@ makeRandomStandardOperation(const qc::Qubit nrQubits, const qc::Qubit min,
   std::uniform_int_distribution<> randomDistrOpType(H, RZX);
   auto randomOpType = static_cast<OpType>(randomDistrOpType(randomGenerator));
   const qc::Qubit randomTarget1 = randomNumbers[0];
-  qc::Qubit       randomTarget2{min};
+  qc::Qubit randomTarget2{min};
   if (randomNumbers.size() > 1) {
     randomTarget2 = randomNumbers[1];
   };
@@ -273,7 +273,7 @@ generatePartiallyEquivalentCircuits(const size_t n, const qc::Qubit d,
   // 3) Partially equivalent subcircuits
   // Divide data qubits into groups of size 1 or 2. For each group, we apply
   // pre-generated subcircuits, which are pairwise partially equivalent.
-  qc::Qubit                                groupBeginIndex = 0;
+  qc::Qubit groupBeginIndex = 0;
   std::uniform_int_distribution<qc::Qubit> randomDistrGroupSize(1, 2);
   while (groupBeginIndex < d) {
     qc::Qubit groupSize = 1;
@@ -342,20 +342,20 @@ class PartialEquivalenceTest : public testing::Test {
     qc1 = qc::QuantumComputation(nqubits, nqubits);
     qc2 = qc::QuantumComputation(nqubits, nqubits);
 
-    config.execution.runSimulationChecker   = false;
-    config.execution.runAlternatingChecker  = false;
+    config.execution.runSimulationChecker = false;
+    config.execution.runAlternatingChecker = false;
     config.execution.runConstructionChecker = false;
-    config.execution.runZXChecker           = false;
-    config.execution.nthreads               = 1;
+    config.execution.runZXChecker = false;
+    config.execution.nthreads = 1;
 
     config.functionality.checkPartialEquivalence = true;
   }
 
 protected:
-  std::size_t            nqubits = 3U;
+  std::size_t nqubits = 3U;
   qc::QuantumComputation qc1;
   qc::QuantumComputation qc2;
-  ec::Configuration      config{};
+  ec::Configuration config{};
 };
 
 TEST_F(PartialEquivalenceTest, AlternatingCheckerGarbage) {
@@ -717,7 +717,7 @@ TEST_F(PartialEquivalenceTest, MQTBenchGrover3Qubits) {
   c2.print(std::cout);
   // alternating checker
   config.execution.runConstructionChecker = false;
-  config.execution.runAlternatingChecker  = true;
+  config.execution.runAlternatingChecker = true;
   ec::EquivalenceCheckingManager ecm2(c1, c2, config);
   ecm2.run();
   EXPECT_EQ(ecm2.equivalence(),
@@ -741,7 +741,7 @@ TEST_F(PartialEquivalenceTest, MQTBenchGrover7Qubits) {
 
   // alternating checker
   config.execution.runConstructionChecker = false;
-  config.execution.runAlternatingChecker  = true;
+  config.execution.runAlternatingChecker = true;
   ec::EquivalenceCheckingManager ecm2(c1, c2, config);
   ecm2.run();
   EXPECT_EQ(ecm2.equivalence(), ec::EquivalenceCriterion::Equivalent);
@@ -880,15 +880,15 @@ TEST_F(PartialEquivalenceTest, ConstructionCheckerSliQECPeriodFinding8Qubits) {
   EXPECT_EQ(ecm.equivalence(), ec::EquivalenceCriterion::Equivalent);
 }
 
-void partialEquivalencCheckingBenchmarks(const qc::Qubit          minN,
-                                         const qc::Qubit          maxN,
-                                         const size_t             reps,
-                                         const bool               addAncilla,
+void partialEquivalencCheckingBenchmarks(const qc::Qubit minN,
+                                         const qc::Qubit maxN,
+                                         const size_t reps,
+                                         const bool addAncilla,
                                          const ec::Configuration& config) {
   std::mt19937 gen(55);
 
   for (qc::Qubit n = minN; n < maxN; n++) {
-    double      totalTime{0};
+    double totalTime{0};
     std::size_t totalGates{0};
     for (size_t k = 0; k < reps; k++) {
       qc::Qubit d{0};
@@ -899,7 +899,7 @@ void partialEquivalencCheckingBenchmarks(const qc::Qubit          minN,
         d = n;
       }
       std::uniform_int_distribution<qc::Qubit> nrDataQubits(1, d);
-      const qc::Qubit                          m = nrDataQubits(gen);
+      const qc::Qubit m = nrDataQubits(gen);
 
       const auto [c1, c2] = dd::generatePartiallyEquivalentCircuits(n, d, m);
 
@@ -923,18 +923,18 @@ void partialEquivalencCheckingBenchmarks(const qc::Qubit          minN,
 
 TEST_F(PartialEquivalenceTest, Benchmark) {
   config.execution.runConstructionChecker = true;
-  const size_t minN                       = 2;
-  const size_t maxN                       = 8;
-  const size_t reps                       = 10;
+  const size_t minN = 2;
+  const size_t maxN = 8;
+  const size_t reps = 10;
   std::cout << "Partial equivalence check\n";
   partialEquivalencCheckingBenchmarks(minN, maxN, reps, true, config);
 }
 
 TEST_F(PartialEquivalenceTest, ZeroAncillaBenchmark) {
   config.execution.runAlternatingChecker = true;
-  const size_t minN                      = 3;
-  const size_t maxN                      = 14;
-  const size_t reps                      = 10;
+  const size_t minN = 3;
+  const size_t maxN = 14;
+  const size_t reps = 10;
   std::cout << "Zero-ancilla partial equivalence check\n";
   partialEquivalencCheckingBenchmarks(minN, maxN, reps, false, config);
 }

--- a/test/test_simple_circuit_identities.cpp
+++ b/test/test_simple_circuit_identities.cpp
@@ -7,6 +7,8 @@
 #include "Definitions.hpp"
 #include "EquivalenceCheckingManager.hpp"
 #include "QuantumComputation.hpp"
+#include "checker/dd/applicationscheme/ApplicationScheme.hpp"
+#include "checker/dd/applicationscheme/GateCostApplicationScheme.hpp"
 
 #include "gtest/gtest.h"
 #include <iostream>
@@ -23,7 +25,7 @@ protected:
   qc::QuantumComputation qcAlternative;
   ec::Configuration config{};
 
-  std::unique_ptr<ec::EquivalenceCheckingManager> ecm{};
+  std::unique_ptr<ec::EquivalenceCheckingManager> ecm;
 
   void SetUp() override {
     const auto [circ1, circ2] = GetParam().second;

--- a/test/test_simple_circuit_identities.cpp
+++ b/test/test_simple_circuit_identities.cpp
@@ -21,7 +21,7 @@ class SimpleCircuitIdentitiesTest
 protected:
   qc::QuantumComputation qcOriginal;
   qc::QuantumComputation qcAlternative;
-  ec::Configuration      config{};
+  ec::Configuration config{};
 
   std::unique_ptr<ec::EquivalenceCheckingManager> ecm{};
 
@@ -32,11 +32,11 @@ protected:
     std::stringstream ss2{circ2};
     qcAlternative.import(ss2, qc::Format::OpenQASM2);
 
-    config.optimizations.reconstructSWAPs     = false;
+    config.optimizations.reconstructSWAPs = false;
     config.optimizations.fuseSingleQubitGates = false;
-    config.optimizations.reorderOperations    = false;
-    config.optimizations.elidePermutations    = false;
-    config.execution.runZXChecker             = true;
+    config.optimizations.reorderOperations = false;
+    config.optimizations.elidePermutations = false;
+    config.execution.runZXChecker = true;
     EXPECT_NO_THROW(ecm = std::make_unique<ec::EquivalenceCheckingManager>(
                         qcOriginal, qcAlternative, config););
   }

--- a/test/test_symbolic.cpp
+++ b/test/test_symbolic.cpp
@@ -3,10 +3,15 @@
 // See README.md or go to https://github.com/cda-tum/qcec for more information.
 //
 
+#include "Configuration.hpp"
 #include "EquivalenceCheckingManager.hpp"
+#include "EquivalenceCriterion.hpp"
 #include "QuantumComputation.hpp"
+#include "dd/DDDefinitions.hpp"
+#include "operations/Control.hpp"
+#include "operations/Expression.hpp"
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 using namespace qc;
 using namespace sym;

--- a/test/test_symbolic.cpp
+++ b/test/test_symbolic.cpp
@@ -14,7 +14,7 @@ class SymbolicTest : public ::testing::Test {
 public:
   Variable x = Variable("x");
 
-  Symbolic xMonom    = Symbolic{Term<dd::fp>{x}};
+  Symbolic xMonom = Symbolic{Term<dd::fp>{x}};
   Symbolic xMonomNeg = Symbolic{-Term<dd::fp>{x}};
 
   QuantumComputation symQc1 = QuantumComputation(1);
@@ -50,8 +50,8 @@ TEST_F(SymbolicTest, SymbolicNonEqu) {
 TEST_F(SymbolicTest, Timeout) {
   // construct large circuit
   constexpr auto numLayers = 100000;
-  symQc1                   = qc::QuantumComputation(2);
-  symQc2                   = qc::QuantumComputation(2);
+  symQc1 = qc::QuantumComputation(2);
+  symQc2 = qc::QuantumComputation(2);
   for (auto i = 0; i < numLayers; ++i) {
     symQc1.cx(1_pc, 0);
     symQc1.rx(xMonom, 0);

--- a/test/test_zx.cpp
+++ b/test/test_zx.cpp
@@ -23,19 +23,19 @@ class ZXTest : public testing::TestWithParam<std::string> {
 protected:
   qc::QuantumComputation qcOriginal;
   qc::QuantumComputation qcAlternative;
-  ec::Configuration      config{};
+  ec::Configuration config{};
 
   std::unique_ptr<ec::EquivalenceCheckingManager> ecm;
 
-  std::string testOriginal       = "./circuits/test/test.real";
+  std::string testOriginal = "./circuits/test/test.real";
   std::string testAlternativeDir = "./circuits/test/";
 
   void SetUp() override {
-    config.execution.parallel               = true;
+    config.execution.parallel = true;
     config.execution.runConstructionChecker = false;
-    config.execution.runAlternatingChecker  = false;
-    config.execution.runSimulationChecker   = false;
-    config.execution.runZXChecker           = true;
+    config.execution.runAlternatingChecker = false;
+    config.execution.runSimulationChecker = false;
+    config.execution.runZXChecker = true;
   }
 
   void TearDown() override { std::cout << ecm->getResults() << "\n"; }
@@ -86,8 +86,8 @@ TEST_F(ZXTest, Timeout) {
 
   // construct large circuit
   constexpr auto numLayers = 10000;
-  qcOriginal               = qc::QuantumComputation(2);
-  qcAlternative            = qc::QuantumComputation(2);
+  qcOriginal = qc::QuantumComputation(2);
+  qcAlternative = qc::QuantumComputation(2);
   for (auto i = 0; i < numLayers; ++i) {
     qcOriginal.cx(1, 0);
     qcOriginal.h(0);
@@ -166,9 +166,9 @@ TEST_F(ZXTest, Permutation) {
   qc2.x(0);
   qc2.x(1);
   qc::Permutation p;
-  p[0]                  = 1;
-  p[1]                  = 0;
-  qc1.initialLayout     = p;
+  p[0] = 1;
+  p[1] = 0;
+  qc1.initialLayout = p;
   qc1.outputPermutation = p;
 
   ecm = std::make_unique<ec::EquivalenceCheckingManager>(qc1, qc2, config);
@@ -196,8 +196,8 @@ TEST_F(ZXTest, Ancilla) {
 TEST_F(ZXTest, ZXWrongAncilla) {
   using namespace qc::literals;
 
-  auto            qc1 = qc::QuantumComputation(1);
-  auto            qc2 = qc::QuantumComputation(2);
+  auto qc1 = qc::QuantumComputation(1);
+  auto qc2 = qc::QuantumComputation(2);
   qc::Permutation p1{};
   p1[0] = 0;
   qc1.x(0);
@@ -256,19 +256,19 @@ class ZXTestCompFlow : public testing::TestWithParam<std::string> {
 protected:
   qc::QuantumComputation qcOriginal;
   qc::QuantumComputation qcTranspiled;
-  ec::Configuration      config{};
+  ec::Configuration config{};
 
   std::unique_ptr<ec::EquivalenceCheckingManager> ecm;
 
-  std::string testOriginalDir   = "./circuits/original/";
+  std::string testOriginalDir = "./circuits/original/";
   std::string testTranspiledDir = "./circuits/transpiled/";
 
   void SetUp() override {
-    config.execution.parallel               = false;
+    config.execution.parallel = false;
     config.execution.runConstructionChecker = false;
-    config.execution.runAlternatingChecker  = false;
-    config.execution.runSimulationChecker   = false;
-    config.execution.runZXChecker           = true;
+    config.execution.runAlternatingChecker = false;
+    config.execution.runSimulationChecker = false;
+    config.execution.runZXChecker = true;
 
     qcOriginal.import(testOriginalDir + GetParam() + ".real");
     qcTranspiled.import(testTranspiledDir + GetParam() + "_transpiled.qasm");
@@ -295,7 +295,7 @@ TEST_P(ZXTestCompFlow, EquivalenceCompilationFlow) {
 
 TEST(ZXTestsMisc, IdentityNotHadamard) {
   const auto qc1 = qc::QuantumComputation(1);
-  auto       qc2 = qc::QuantumComputation(1);
+  auto qc2 = qc::QuantumComputation(1);
   qc2.h(0);
 
   auto ecm = ec::EquivalenceCheckingManager(qc1, qc2);
@@ -402,10 +402,10 @@ TEST_F(ZXTest, IdleQubit) {
   qc2.measure(4, 2);
   qc2.initializeIOMapping();
 
-  config.execution.runZXChecker           = true;
-  config.execution.parallel               = false;
-  config.execution.runSimulationChecker   = false;
-  config.execution.runAlternatingChecker  = false;
+  config.execution.runZXChecker = true;
+  config.execution.parallel = false;
+  config.execution.runSimulationChecker = false;
+  config.execution.runAlternatingChecker = false;
   config.execution.runConstructionChecker = false;
   ecm = std::make_unique<ec::EquivalenceCheckingManager>(qc1, qc2, config);
 
@@ -438,10 +438,10 @@ TEST_F(ZXTest, TwoQubitRotations) {
   qc2.cx(0, 1);
   qc2.rx(-qc::PI_2, 0);
   qc2.rx(-qc::PI_2, 1);
-  config.execution.runZXChecker           = true;
-  config.execution.parallel               = false;
-  config.execution.runSimulationChecker   = false;
-  config.execution.runAlternatingChecker  = false;
+  config.execution.runZXChecker = true;
+  config.execution.parallel = false;
+  config.execution.runSimulationChecker = false;
+  config.execution.runAlternatingChecker = false;
   config.execution.runConstructionChecker = false;
   ecm = std::make_unique<ec::EquivalenceCheckingManager>(qc1, qc2, config);
 


### PR DESCRIPTION
## Description

This PR aims to fix all the new warnings that were introduced in clang-tidy versions 18, which have been enabled with the switch to the `mqt-workflows@v1.0.0`.

The first commit, which will later be reverted, just triggers a full clang-tidy run on the whole codebase.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.