### PR TITLE
🚸 add configurable repo owner for mqt-core dependency

### DIFF
--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -24,11 +24,13 @@ set(MQT_CORE_VERSION 2.5.1
     CACHE STRING "MQT Core version")
 set(MQT_CORE_REV "0e4ff9e0521886449027b252c65913e1afa863b0"
     CACHE STRING "MQT Core identifier (tag, branch or commit hash)")
+set(MQT_CORE_REPO_OWNER "cda-tum"
+	CACHE STRING "MQT Core repository owner (change when using a fork)")
 # cmake-format: on
 if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
   FetchContent_Declare(
     mqt-core
-    GIT_REPOSITORY https://github.com/cda-tum/mqt-core.git
+    GIT_REPOSITORY https://github.com/${MQT_CORE_REPO_OWNER}/mqt-core.git
     GIT_TAG ${MQT_CORE_REV}
     FIND_PACKAGE_ARGS ${MQT_CORE_VERSION})
   list(APPEND FETCH_PACKAGES mqt-core)
@@ -37,7 +39,7 @@ else()
   if(NOT mqt-core_FOUND)
     FetchContent_Declare(
       mqt-core
-      GIT_REPOSITORY https://github.com/cda-tum/mqt-core.git
+      GIT_REPOSITORY https://github.com/${MQT_CORE_REPO_OWNER}/mqt-core.git
       GIT_TAG ${MQT_CORE_REV})
     list(APPEND FETCH_PACKAGES mqt-core)
   endif()


### PR DESCRIPTION
## Description

This small PR adds a configuration option for the owner of the mqt-core dependency that is fetched via FetchContent. This should make it easier to point to forks of mqt-core.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
