### PR TITLE
➖ only require `typing_extensions` on Python < 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = [
     "importlib_resources>=5.0; python_version < '3.10'",
-    "typing_extensions>=4.2",
+    "typing_extensions>=4.2; python_version < '3.11'", # used for typing.Unpack
     "qiskit[qasm3-import]>=1.0.0",
 ]
 dynamic = ["version"]
@@ -226,6 +226,7 @@ ignore = [
     "PT004",   # Incorrect, just usefixtures instead.
     "S101",    # Use of assert detected
 ]
+typing-modules = ["mqt.qcec._compat.typing"]
 isort.required-imports = ["from __future__ import annotations"]
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]

--- a/src/mqt/qcec/_compat/typing.py
+++ b/src/mqt/qcec/_compat/typing.py
@@ -1,0 +1,16 @@
+# noqa: A005
+from __future__ import annotations
+
+import sys
+
+if sys.version_info < (3, 11):
+    from typing_extensions import Unpack
+
+else:
+    from typing import Unpack
+
+__all__ = ["Unpack"]
+
+
+def __dir__() -> list[str]:
+    return __all__

--- a/src/mqt/qcec/verify.py
+++ b/src/mqt/qcec/verify.py
@@ -6,8 +6,8 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from qiskit import QuantumCircuit
-    from typing_extensions import Unpack
 
+    from ._compat.typing import Unpack
     from .configuration import ConfigurationOptions
 
 from . import Configuration, EquivalenceCheckingManager

--- a/src/mqt/qcec/verify_compilation_flow.py
+++ b/src/mqt/qcec/verify_compilation_flow.py
@@ -6,8 +6,7 @@ import warnings
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing_extensions import Unpack
-
+    from ._compat.typing import Unpack
     from .configuration import ConfigurationOptions
 
 from qiskit import QuantumCircuit


### PR DESCRIPTION
## Description

This PR removes the `typing_extensions` dependency for Python >= 3.11 and adds a compatibility typing module to abstract away the difference across Python versions.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
