### PR TITLE
🩹 make sure to define `Py_GIL_DISABLED` on Windows for Python 3.13t

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,11 @@ if(BUILD_MQT_QCEC_BINDINGS)
       ON
       CACHE BOOL "Prevent multiple searches for Python and instead cache the results.")
 
+  if(DISABLE_GIL)
+    message(STATUS "Disabling Python GIL")
+    add_compile_definitions(Py_GIL_DISABLED)
+  endif()
+
   # top-level call to find Python
   find_package(
     Python 3.8 REQUIRED

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,13 @@ BUILD_MQT_QCEC_TESTS = "OFF"
 BUILD_MQT_QCEC_BINDINGS = "ON"
 ENABLE_IPO = "ON"
 
+[[tool.scikit-build.overrides]]
+if.python-version = ">=3.13"
+if.abi-flags = "t"
+if.platform-system = "win32"
+inherit.cmake.define = "append"
+cmake.define.DISABLE_GIL = "1"
+
 
 [tool.check-sdist]
 sdist-only = ["src/mqt/qcec/_version.py"]


### PR DESCRIPTION
## Description

As pointed out in https://github.com/pypa/cibuildwheel/issues/1975#issuecomment-2296995654 free-threading (Python 3.13t) builds on Windows need to have `Py_GIL_DISABLED` set in order to properly work.
This PR ensures that the corresponding setting is always set.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
