### PR TITLE
🐛 Fix definition issue for DCX gate in DD package

### DIFF
--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -22,7 +22,7 @@ endif()
 # cmake-format: off
 set(MQT_CORE_VERSION 2.7.0
     CACHE STRING "MQT Core version")
-set(MQT_CORE_REV "2ccf532b66998af376c256ae94a39eed802b990c"
+set(MQT_CORE_REV "9f885e4a47e3f65e380dbe855ef9fabcc5ed570e"
     CACHE STRING "MQT Core identifier (tag, branch or commit hash)")
 set(MQT_CORE_REPO_OWNER "cda-tum"
 	CACHE STRING "MQT Core repository owner (change when using a fork)")

--- a/test/test_simple_circuit_identities.cpp
+++ b/test/test_simple_circuit_identities.cpp
@@ -90,6 +90,12 @@ INSTANTIATE_TEST_SUITE_P(
                 "q[0], q[1];\n",
                 "OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[2];\ns q[0]; s "
                 "q[1]; h q[0]; cx q[0],q[1]; cx q[1],q[0]; h q[1];\n"}},
+        std::pair{
+            "dcx_decomposition",
+            std::pair{"OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[2];\ndcx "
+                      "q[0], q[1];\n",
+                      "OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[2];\ncx "
+                      "q[0],q[1];\ncx q[1],q[0];\n"}},
         std::pair{"Global_Phase",
                   std::pair{"OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg "
                             "q[1];\nz q[0]; x q[0]; z q[0];\n",


### PR DESCRIPTION
## Description

Fixes #489.
The DCX gate (as well as the `xx_minus_yy` gate) had wrong gate matrix definitions in the underlying DD package within mqt-core.
These have now been fixed. A test has been added to check that the proper definition can be successfully verified.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
