### PR TITLE
⬆️👽  update to latest MQT Core version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-python-tests)
     uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-ci.yml@v1.5
+    with:
+      # Runs all Python tests in separate jobs to maximize parallelism
+      run-tests-individually: true
 
   code-ql:
     name: 📝 CodeQL

--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -22,7 +22,7 @@ endif()
 # cmake-format: off
 set(MQT_CORE_VERSION 2.7.1
     CACHE STRING "MQT Core version")
-set(MQT_CORE_REV "ee7482834c75c6ba7b5ce5fbd74829cb513e3c01"
+set(MQT_CORE_REV "a7032324072fef82cc5edc8798ca8b72870fb8d2"
     CACHE STRING "MQT Core identifier (tag, branch or commit hash)")
 set(MQT_CORE_REPO_OWNER "cda-tum"
 	CACHE STRING "MQT Core repository owner (change when using a fork)")

--- a/src/checker/dd/DDAlternatingChecker.cpp
+++ b/src/checker/dd/DDAlternatingChecker.cpp
@@ -52,8 +52,8 @@ void DDAlternatingChecker::initialize() {
 void DDAlternatingChecker::execute() {
   while (!taskManager1.finished() && !taskManager2.finished() && !isDone()) {
     // skip over any SWAP operations
-    taskManager1.applySwapOperations(functionality);
-    taskManager2.applySwapOperations(functionality);
+    taskManager1.applySwapOperations();
+    taskManager2.applySwapOperations();
 
     if (!taskManager1.finished() && !taskManager2.finished() && !isDone()) {
       // whenever the current functionality resembles the identity, identical

--- a/src/checker/dd/DDSimulationChecker.cpp
+++ b/src/checker/dd/DDSimulationChecker.cpp
@@ -38,6 +38,7 @@ EquivalenceCriterion DDSimulationChecker::checkEquivalence() {
   // adjust reference counts to facilitate reuse of the simulation checker
   taskManager1.decRef();
   taskManager2.decRef();
+  dd->decRef(initialState);
 
   return equivalence;
 }

--- a/src/checker/dd/simulation/StateGenerator.cpp
+++ b/src/checker/dd/simulation/StateGenerator.cpp
@@ -143,15 +143,15 @@ qc::VectorDD StateGenerator::generateRandomStabilizerState(
   // circuit
   auto stabilizer = simulate(&rcs, dd.makeZeroState(randomQubits), dd);
 
-  // decrease the ref count right after so that it stays correct later on
-  dd.decRef(stabilizer);
-
   // add |0> edges for all the ancillary qubits
   auto initial = stabilizer;
   for (std::size_t p = randomQubits; p < totalQubits; ++p) {
     initial = dd.makeDDNode(static_cast<dd::Qubit>(p),
                             std::array{initial, qc::VectorDD::zero()});
   }
+  // properly set the reference count for the state
+  dd.incRef(initial);
+  dd.decRef(stabilizer);
 
   // return the resulting decision diagram
   return initial;


### PR DESCRIPTION
## Description

This PR updates the MQT Core version used in QCEC to the latest version. This includes changes from cda-tum/mqt-core#674 and cda-tum/mqt-core#764.
SWAP eliding is now performed explicitly in QCEC instead of implicitly in the `getDD` method of MQT Core.
Furthermore, states generated by the DD package now have their ref count increased by default, which required subtle changes to the ref counting scheme.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
