### PR TITLE
⬆️👽 update to latest MQT Core version

### DIFF
--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -22,7 +22,7 @@ endif()
 # cmake-format: off
 set(MQT_CORE_VERSION 2.7.1
     CACHE STRING "MQT Core version")
-set(MQT_CORE_REV "a7032324072fef82cc5edc8798ca8b72870fb8d2"
+set(MQT_CORE_REV "5c3cb8edf0f43663a8edc7ae77c753926b466802"
     CACHE STRING "MQT Core identifier (tag, branch or commit hash)")
 set(MQT_CORE_REPO_OWNER "cda-tum"
 	CACHE STRING "MQT Core repository owner (change when using a fork)")

--- a/include/EquivalenceCheckingManager.hpp
+++ b/include/EquivalenceCheckingManager.hpp
@@ -103,7 +103,7 @@ public:
 
   void reset() {
     stateGenerator.clear();
-    results = {};
+    results = Results();
     checkers.clear();
   }
 

--- a/include/checker/dd/TaskManager.hpp
+++ b/include/checker/dd/TaskManager.hpp
@@ -26,7 +26,7 @@ template <class DDType, class Config = dd::DDPackageConfig> class TaskManager {
 
 public:
   TaskManager(const qc::QuantumComputation& circ, DDPackage& dd,
-              const ec::Direction& dir) noexcept
+              const Direction& dir) noexcept
       : qc(&circ), package(&dd), direction(dir),
         permutation(circ.initialLayout), iterator(circ.begin()),
         end(circ.end()) {}
@@ -55,10 +55,10 @@ public:
   }
 
   [[nodiscard]] qc::MatrixDD getDD() {
-    return dd::getDD(iterator->get(), *package, permutation);
+    return dd::getDD(**iterator, *package, permutation);
   }
   [[nodiscard]] qc::MatrixDD getInverseDD() {
-    return dd::getInverseDD(iterator->get(), *package, permutation);
+    return dd::getInverseDD(**iterator, *package, permutation);
   }
 
   [[nodiscard]] const qc::QuantumComputation* getCircuit() const noexcept {
@@ -124,7 +124,7 @@ public:
 
   void reduceAncillae(DDType& state) {
     if constexpr (std::is_same_v<DDType, qc::MatrixDD>) {
-      state = package->reduceAncillae(state, qc->ancillary,
+      state = package->reduceAncillae(state, qc->getAncillary(),
                                       static_cast<bool>(direction));
     }
   }
@@ -136,9 +136,9 @@ public:
    **/
   void reduceGarbage(DDType& state) {
     if constexpr (std::is_same_v<DDType, qc::VectorDD>) {
-      state = package->reduceGarbage(state, qc->garbage, true);
+      state = package->reduceGarbage(state, qc->getGarbage(), true);
     } else if constexpr (std::is_same_v<DDType, qc::MatrixDD>) {
-      state = package->reduceGarbage(state, qc->garbage,
+      state = package->reduceGarbage(state, qc->getGarbage(),
                                      static_cast<bool>(direction), true);
     }
   }
@@ -153,7 +153,7 @@ public:
 private:
   const qc::QuantumComputation* qc{};
   DDPackage* package;
-  ec::Direction direction = Direction::Left;
+  Direction direction = Direction::Left;
   qc::Permutation permutation{};
   decltype(qc->begin()) iterator;
   decltype(qc->end()) end;

--- a/src/checker/dd/simulation/StateGenerator.cpp
+++ b/src/checker/dd/simulation/StateGenerator.cpp
@@ -5,6 +5,7 @@
 
 #include "checker/dd/simulation/StateGenerator.hpp"
 
+#include "Definitions.hpp"
 #include "algorithms/RandomCliffordCircuit.hpp"
 #include "checker/dd/DDPackageConfigs.hpp"
 #include "checker/dd/simulation/StateType.hpp"
@@ -134,14 +135,14 @@ qc::VectorDD StateGenerator::generateRandomStabilizerState(
   // determine how many qubits truly are random
   const std::size_t randomQubits = totalQubits - ancillaryQubits;
 
-  // generate a random Clifford circuit with appropriate depth
-  auto rcs = qc::RandomCliffordCircuit(
-      randomQubits,
+  // generate a random Clifford circuit with the appropriate depth
+  const auto rcs = qc::createRandomCliffordCircuit(
+      static_cast<qc::Qubit>(randomQubits),
       static_cast<std::size_t>(std::round(std::log2(randomQubits))), mt());
 
   // generate the associated stabilizer state by simulating the Clifford
   // circuit
-  auto stabilizer = simulate(&rcs, dd.makeZeroState(randomQubits), dd);
+  const auto stabilizer = simulate(rcs, dd.makeZeroState(randomQubits), dd);
 
   // add |0> edges for all the ancillary qubits
   auto initial = stabilizer;

--- a/test/test_dynamic_circuits.cpp
+++ b/test/test_dynamic_circuits.cpp
@@ -20,14 +20,14 @@
 #include <stdexcept>
 #include <string>
 
-class DynamicCircuitTestExactQPE : public testing::TestWithParam<std::size_t> {
+class DynamicCircuitTestExactQPE : public testing::TestWithParam<qc::Qubit> {
 protected:
-  std::size_t precision{};
+  qc::Qubit precision{};
   qc::fp theta{};
   std::size_t expectedResult{};
   std::string expectedResultRepresentation;
-  std::unique_ptr<qc::QuantumComputation> qpe;
-  std::unique_ptr<qc::QuantumComputation> iqpe;
+  qc::QuantumComputation qpe;
+  qc::QuantumComputation iqpe;
   std::unique_ptr<dd::Package<>> dd;
   std::ofstream ofs;
 
@@ -39,10 +39,12 @@ protected:
 
     dd = std::make_unique<dd::Package<>>(precision + 1);
 
-    qpe = std::make_unique<qc::QPE>(precision);
+    qpe = qc::createQPE(precision);
 
-    const auto lambda = dynamic_cast<qc::QPE*>(qpe.get())->lambda;
-    iqpe = std::make_unique<qc::QPE>(lambda, precision, true);
+    // extract lambda from QPE global phase
+    const auto lambda = qpe.getGlobalPhase();
+
+    iqpe = qc::createIterativeQPE(lambda, precision);
 
     std::cout << "Estimating lambda = " << lambda << "π up to " << precision
               << "-bit precision.\n";
@@ -89,7 +91,7 @@ protected:
 };
 
 INSTANTIATE_TEST_SUITE_P(
-    Eval, DynamicCircuitTestExactQPE, testing::Range<std::size_t>(1U, 64U, 5U),
+    Eval, DynamicCircuitTestExactQPE, testing::Range<qc::Qubit>(1U, 64U, 5U),
     [](const testing::TestParamInfo<DynamicCircuitTestExactQPE::ParamType>&
            inf) {
       const auto nqubits = inf.param;
@@ -104,22 +106,21 @@ INSTANTIATE_TEST_SUITE_P(
     });
 
 TEST_P(DynamicCircuitTestExactQPE, UnitaryEquivalence) {
-  ec::EquivalenceCheckingManager ecm(*qpe, *iqpe, config);
+  ec::EquivalenceCheckingManager ecm(qpe, iqpe, config);
   ecm.run();
   EXPECT_EQ(ecm.equivalence(), ec::EquivalenceCriterion::Equivalent);
 }
 
-class DynamicCircuitTestInexactQPE
-    : public testing::TestWithParam<std::size_t> {
+class DynamicCircuitTestInexactQPE : public testing::TestWithParam<qc::Qubit> {
 protected:
-  std::size_t precision{};
+  qc::Qubit precision{};
   dd::fp theta{};
   std::size_t expectedResult{};
   std::string expectedResultRepresentation;
   std::size_t secondExpectedResult{};
   std::string secondExpectedResultRepresentation;
-  std::unique_ptr<qc::QuantumComputation> qpe;
-  std::unique_ptr<qc::QuantumComputation> iqpe;
+  qc::QuantumComputation qpe;
+  qc::QuantumComputation iqpe;
   std::unique_ptr<dd::Package<>> dd;
   std::ofstream ofs;
 
@@ -131,10 +132,12 @@ protected:
 
     dd = std::make_unique<dd::Package<>>(precision + 1);
 
-    qpe = std::make_unique<qc::QPE>(precision, false);
+    qpe = qc::createQPE(precision);
 
-    const auto lambda = dynamic_cast<qc::QPE*>(qpe.get())->lambda;
-    iqpe = std::make_unique<qc::QPE>(lambda, precision, true);
+    // extract lambda from QPE global phase
+    const auto lambda = qpe.getGlobalPhase();
+
+    iqpe = qc::createIterativeQPE(lambda, precision);
 
     std::cout << "Estimating lambda = " << lambda << "π up to " << precision
               << "-bit precision.\n";
@@ -192,32 +195,32 @@ protected:
   }
 };
 
-INSTANTIATE_TEST_SUITE_P(Eval, DynamicCircuitTestInexactQPE,
-                         testing::Range<std::size_t>(1U, 15U, 3U),
-                         [](const testing::TestParamInfo<
-                             DynamicCircuitTestInexactQPE::ParamType>& inf) {
-                           const auto nqubits = inf.param;
-                           std::stringstream ss{};
-                           ss << nqubits;
-                           if (nqubits == 1) {
-                             ss << "_qubit";
-                           } else {
-                             ss << "_qubits";
-                           }
-                           return ss.str();
-                         });
+INSTANTIATE_TEST_SUITE_P(
+    Eval, DynamicCircuitTestInexactQPE, testing::Range<qc::Qubit>(1U, 15U, 3U),
+    [](const testing::TestParamInfo<DynamicCircuitTestInexactQPE::ParamType>&
+           inf) {
+      const auto nqubits = inf.param;
+      std::stringstream ss{};
+      ss << nqubits;
+      if (nqubits == 1) {
+        ss << "_qubit";
+      } else {
+        ss << "_qubits";
+      }
+      return ss.str();
+    });
 
 TEST_P(DynamicCircuitTestInexactQPE, UnitaryEquivalence) {
-  ec::EquivalenceCheckingManager ecm(*qpe, *iqpe, config);
+  ec::EquivalenceCheckingManager ecm(qpe, iqpe, config);
   ecm.run();
   EXPECT_EQ(ecm.equivalence(), ec::EquivalenceCriterion::Equivalent);
 }
 
-class DynamicCircuitTestBV : public testing::TestWithParam<std::size_t> {
+class DynamicCircuitTestBV : public testing::TestWithParam<qc::Qubit> {
 protected:
-  std::size_t bitwidth{};
-  std::unique_ptr<qc::QuantumComputation> bv;
-  std::unique_ptr<qc::QuantumComputation> dbv;
+  qc::Qubit bitwidth{};
+  qc::QuantumComputation bv;
+  qc::QuantumComputation dbv;
   std::unique_ptr<dd::Package<>> dd;
   std::ofstream ofs;
 
@@ -229,13 +232,12 @@ protected:
 
     dd = std::make_unique<dd::Package<>>(bitwidth + 1);
 
-    bv = std::make_unique<qc::BernsteinVazirani>(bitwidth);
+    bv = qc::createBernsteinVazirani(bitwidth);
 
-    const auto s = dynamic_cast<qc::BernsteinVazirani*>(bv.get())->s;
-    dbv = std::make_unique<qc::BernsteinVazirani>(s, bitwidth, true);
+    const auto expected = bv.getName().substr(3);
+    dbv =
+        qc::createIterativeBernsteinVazirani(qc::BitString(expected), bitwidth);
 
-    const auto expected =
-        dynamic_cast<qc::BernsteinVazirani*>(bv.get())->expected;
     std::cout << "Hidden bitstring: " << expected << " (" << bitwidth
               << " qubits)\n";
 
@@ -245,7 +247,7 @@ protected:
 };
 
 INSTANTIATE_TEST_SUITE_P(
-    Eval, DynamicCircuitTestBV, testing::Range<std::size_t>(1U, 64U, 5U),
+    Eval, DynamicCircuitTestBV, testing::Range<qc::Qubit>(1U, 64U, 5U),
     [](const testing::TestParamInfo<DynamicCircuitTestBV::ParamType>& inf) {
       const auto nqubits = inf.param;
       std::stringstream ss{};
@@ -259,16 +261,16 @@ INSTANTIATE_TEST_SUITE_P(
     });
 
 TEST_P(DynamicCircuitTestBV, UnitaryEquivalence) {
-  ec::EquivalenceCheckingManager ecm(*bv, *dbv, config);
+  ec::EquivalenceCheckingManager ecm(bv, dbv, config);
   ecm.run();
   EXPECT_EQ(ecm.equivalence(), ec::EquivalenceCriterion::Equivalent);
 }
 
-class DynamicCircuitTestQFT : public testing::TestWithParam<std::size_t> {
+class DynamicCircuitTestQFT : public testing::TestWithParam<qc::Qubit> {
 protected:
-  std::size_t precision{};
-  std::unique_ptr<qc::QuantumComputation> qft;
-  std::unique_ptr<qc::QuantumComputation> dqft;
+  qc::Qubit precision{};
+  qc::QuantumComputation qft;
+  qc::QuantumComputation dqft;
   std::unique_ptr<dd::Package<>> dd;
   std::ofstream ofs;
 
@@ -280,9 +282,9 @@ protected:
 
     dd = std::make_unique<dd::Package<>>(precision);
 
-    qft = std::make_unique<qc::QFT>(precision);
+    qft = qc::createQFT(precision);
 
-    dqft = std::make_unique<qc::QFT>(precision, true, true);
+    dqft = qc::createIterativeQFT(precision);
 
     config.optimizations.transformDynamicCircuit = true;
     config.optimizations.backpropagateOutputPermutation = true;
@@ -290,7 +292,7 @@ protected:
 };
 
 INSTANTIATE_TEST_SUITE_P(
-    Eval, DynamicCircuitTestQFT, testing::Range<std::size_t>(1U, 65U, 5U),
+    Eval, DynamicCircuitTestQFT, testing::Range<qc::Qubit>(1U, 65U, 5U),
     [](const testing::TestParamInfo<DynamicCircuitTestQFT::ParamType>& inf) {
       const auto nqubits = inf.param;
       std::stringstream ss{};
@@ -304,15 +306,15 @@ INSTANTIATE_TEST_SUITE_P(
     });
 
 TEST_P(DynamicCircuitTestQFT, UnitaryEquivalence) {
-  ec::EquivalenceCheckingManager ecm(*qft, *dqft, config);
+  ec::EquivalenceCheckingManager ecm(qft, dqft, config);
   ecm.run();
   EXPECT_EQ(ecm.equivalence(), ec::EquivalenceCriterion::Equivalent);
 }
 
 TEST(GeneralDynamicCircuitTest, DynamicCircuit) {
-  auto s = qc::BitString(15U);
-  auto bv = qc::BernsteinVazirani(s);
-  auto dbv = qc::BernsteinVazirani(s, true);
+  constexpr auto s = qc::BitString(15U);
+  const auto bv = qc::createBernsteinVazirani(s);
+  const auto dbv = qc::createIterativeBernsteinVazirani(s);
 
   auto config = ec::Configuration{};
   EXPECT_THROW(ec::EquivalenceCheckingManager(bv, dbv, config),


### PR DESCRIPTION
## Description

This PR updates the MQT Core version used in QCEC to the latest version. This includes changes from cda-tum/mqt-core#798.
Algorithms are now constructed slightly differently and some of the methods now take references instead of pointers.

This PR also fixes one compiler warning related to a potential uniniatialized usage in the equivalence checking manager.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
