### PR TITLE
🩹 fix coverage configuration to properly exclude the `literals.py` file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,7 @@ filterwarnings = [
 
 [tool.coverage]
 run.source = ["mqt.qcec"]
-run.omit = ["src/mqt/qcec/types.py"]
+run.omit = ["src/mqt/qcec/literals.py"]
 report.exclude_also = [
     '\.\.\.',
     'if TYPE_CHECKING:',


### PR DESCRIPTION
## Description

This pull request fixes the coverage configuration to properly exclude the `literals.py` file from coverage reports. This ensures accurate reporting by excluding files that are not relevant to coverage metrics.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines