### PR TITLE
🔥✅ remove long-running test circuits from unittests

### DIFF
--- a/test/legacy/test_compilationflow.cpp
+++ b/test/legacy/test_compilationflow.cpp
@@ -43,8 +43,8 @@ INSTANTIATE_TEST_SUITE_P(
     testing::Values("dk27_225", "pcler8_248", "5xp1_194", "alu1_198",
                     "mlp4_245", "dk17_224", "add6_196", "C7552_205", "cu_219",
                     "example2_231", "c2_181", "rd73_312", "cm150a_210",
-                    "cm163a_213", "c2_182", "sym9_317", "mod5adder_306",
-                    "rd84_313", "cm151a_211", "apla_203"),
+                    "cm163a_213", "c2_182", "sym9_317", "cm151a_211",
+                    "apla_203"),
     [](const testing::TestParamInfo<CompilationFlowTest::ParamType>& inf) {
       auto s = inf.param;
       std::replace(s.begin(), s.end(), '-', '_');


### PR DESCRIPTION
## Description

This pull request removes long-running test circuits from the unittests to improve the efficiency of the testing process. This change reduces execution time for test suites, ensuring quicker feedback during development.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines