### PR TITLE
🚸 Use dedicated name and optimize ancillary register setup

### DIFF
--- a/src/EquivalenceCheckingManager.cpp
+++ b/src/EquivalenceCheckingManager.cpp
@@ -189,6 +189,10 @@ void EquivalenceCheckingManager::setupAncillariesAndGarbage() {
   const auto qubitDifference =
       largerCircuit.getNqubits() - smallerCircuit.getNqubits();
 
+  if (qubitDifference == 0) {
+    return;
+  }
+
   std::vector<std::pair<qc::Qubit, std::optional<qc::Qubit>>> removed{};
   removed.reserve(qubitDifference);
 

--- a/src/EquivalenceCheckingManager.cpp
+++ b/src/EquivalenceCheckingManager.cpp
@@ -207,7 +207,7 @@ void EquivalenceCheckingManager::setupAncillariesAndGarbage() {
   }
 
   // add appropriate ancillary register to smaller circuit
-  smallerCircuit.addAncillaryRegister(qubitDifference);
+  smallerCircuit.addAncillaryRegister(qubitDifference, "anc_qcec");
 
   // reverse iterate over the removed qubits and add them back into the larger
   // circuit as ancillary


### PR DESCRIPTION
## Description

This pull request introduces a dedicated name for ancillary registers introduced during preprocessing in QCEC, enhancing clarity and maintainability. Additionally, it optimizes logic by skipping ancillary and garbage setup when there is nothing to set up, improving efficiency.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.