### PR TITLE
💚 fix RtD build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -28,15 +28,19 @@ build:
       - asdf plugin add uv
       - asdf install uv latest
       - asdf global uv latest
+      # Set up build time dependencies including a source distribution of mqt-core.
+      - uv sync --only-group build --only-group docs --no-binary-package mqt-core
+      # The default version of CMake on Ubuntu 24.04 is too old, so we need to install a newer version.
+      - uv pip install cmake
     build:
       html:
-        - uv run --frozen --no-dev --group docs -m sphinx -T -b html -d docs/_build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html
+        - uv run --frozen --no-dev --no-build-isolation-package mqt-qcec -m sphinx -T -b html -d docs/_build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html
       htmlzip:
-        - uv run --frozen --no-dev --group docs -m sphinx -T -b dirhtml -d docs/_build/doctrees -D language=en docs docs/_build/dirhtml
+        - uv run --frozen --no-dev --no-build-isolation-package mqt-qcec -m sphinx -T -b dirhtml -d docs/_build/doctrees -D language=en docs docs/_build/dirhtml
         - mkdir -p $READTHEDOCS_OUTPUT/htmlzip
         - zip -r $READTHEDOCS_OUTPUT/htmlzip/html.zip docs/_build/dirhtml/*
       pdf:
-        - uv run --frozen --no-dev --group docs -m sphinx -T -b latex -d docs/_build/doctrees -D language=en docs docs/_build/latex
+        - uv run --frozen --no-dev --no-build-isolation-package mqt-qcec -m sphinx -T -b latex -d docs/_build/doctrees -D language=en docs docs/_build/latex
         - cd docs/_build/latex && latexmk -pdf -f -dvi- -ps- -interaction=nonstopmode -jobname=$READTHEDOCS_PROJECT
         - mkdir -p $READTHEDOCS_OUTPUT/pdf
         - cp docs/_build/latex/$READTHEDOCS_PROJECT.pdf $READTHEDOCS_OUTPUT/pdf/$READTHEDOCS_PROJECT.pdf


### PR DESCRIPTION
## Description

This small PR fixes the RtD build pipeline.
The manylinux containers use a more recent version of gcc (gcc-14) than the default that comes with Ubuntu 24.04 (gcc-13).
Since `pybind11` hasn't had a new release with the looser compatibility between libraries compiled with different compilers or compiler versions, we need to build mqt-core from source for now in order to build the docs.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
