### PR TITLE
🐛 Fix implementation of `ec::complete()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 
 ## [Unreleased]
 
+### Fixed
+
+- 🐛 Fix implementation of `ec::complete()` ([#929]) ([**@denialhaag**])
+
 ## [3.6.0] - 2026-05-13
 
 _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#360)._
@@ -146,6 +150,7 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 
 <!-- PR links -->
 
+[#929]: https://github.com/munich-quantum-toolkit/qcec/pull/929
 [#907]: https://github.com/munich-quantum-toolkit/qcec/pull/907
 [#837]: https://github.com/munich-quantum-toolkit/qcec/pull/837
 [#831]: https://github.com/munich-quantum-toolkit/qcec/pull/831

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 
 ### Fixed
 
-- 🐛 Fix implementation of `ec::complete()` ([#929]) ([**@denialhaag**])
+- 🐛 Fix segfaults on permutation mismatches in the ZX checker ([#929]) ([**@denialhaag**])
 
 ## [3.6.0] - 2026-05-13
 

--- a/include/checker/zx/ZXChecker.hpp
+++ b/include/checker/zx/ZXChecker.hpp
@@ -116,7 +116,8 @@ private:
   }
 };
 
-qc::Permutation complete(const qc::Permutation& p, std::size_t n);
+qc::Permutation complete(const qc::Permutation& p,
+                         const qc::Permutation& reference);
 qc::Permutation concat(const qc::Permutation& p1, const qc::Permutation& p2);
 qc::Permutation invert(const qc::Permutation& p);
 qc::Permutation invertPermutations(const qc::QuantumComputation& qc);

--- a/src/EquivalenceCheckingManager.cpp
+++ b/src/EquivalenceCheckingManager.cpp
@@ -339,11 +339,12 @@ void EquivalenceCheckingManager::run() {
   if (!configuration.functionality.checkPartialEquivalence &&
       garbageQubitsPresent &&
       equivalence() == EquivalenceCriterion::NotEquivalent) {
-    std::clog << "[QCEC] Warning: at least one of the circuits has garbage "
-                 "qubits, but partial equivalence checking is turned off. In "
-                 "order to take into account the garbage qubits, enable partial"
-                 " equivalence checking. Consult the documentation for more"
-                 "information.\n";
+    std::clog
+        << "[QCEC] Warning: at least one of the circuits has garbage "
+           "qubits, but partial equivalence checking is turned off. In "
+           "order to take into account the garbage qubits, enable partial "
+           "equivalence checking. Consult the documentation for more "
+           "information.\n";
   }
 }
 

--- a/src/checker/zx/ZXChecker.cpp
+++ b/src/checker/zx/ZXChecker.cpp
@@ -23,7 +23,7 @@
 #include <cassert>
 #include <chrono>
 #include <cstddef>
-#include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -161,42 +161,46 @@ qc::Permutation concat(const qc::Permutation& p1,
   return pComb;
 }
 
-qc::Permutation complete(const qc::Permutation& p, const std::size_t n) {
-  if (p.size() == n) {
+qc::Permutation complete(const qc::Permutation& p,
+                         const qc::Permutation& reference) {
+  if (p.size() == reference.size()) {
     return p;
   }
 
   qc::Permutation pComp = p;
 
-  std::vector<bool> mappedTo(n, false);
-  std::unordered_map<std::size_t, bool> mappedFrom;
-  for (const auto [k, v] : p) {
-    mappedFrom[k] = true;
-    mappedTo[v] = true;
+  std::unordered_set<qc::Qubit> usedLogicals;
+  usedLogicals.reserve(p.size());
+  for (const auto& [physical, logical] : p) {
+    usedLogicals.insert(logical);
   }
 
-  // Map qubits greedily
-  for (std::size_t i = 0; i < n; ++i) {
-    // If qubit is already mapped, skip
-    if (mappedTo[i]) {
-      continue;
+  std::vector<qc::Qubit> unmappedPhysicals;
+  unmappedPhysicals.reserve(reference.size() - p.size());
+  for (const auto& [physical, logical] : reference) {
+    if (pComp.find(physical) == pComp.end()) {
+      unmappedPhysicals.emplace_back(physical);
     }
+  }
 
-    for (std::size_t j = 0; j < n; ++j) {
-      if (!mappedFrom.contains(j)) {
-        pComp[static_cast<qc::Qubit>(j)] = static_cast<qc::Qubit>(i);
-        mappedTo[i] = true;
-        mappedFrom[j] = true;
-        break;
-      }
+  std::vector<qc::Qubit> unusedLogicals;
+  unusedLogicals.reserve(reference.size() - p.size());
+  for (const auto& [physical, logical] : reference) {
+    if (!usedLogicals.contains(logical)) {
+      unusedLogicals.emplace_back(logical);
     }
+  }
+
+  assert(unmappedPhysicals.size() == unusedLogicals.size());
+  for (std::size_t i = 0; i < unmappedPhysicals.size(); ++i) {
+    pComp[unmappedPhysicals[i]] = unusedLogicals[i];
   }
   return pComp;
 }
 
 qc::Permutation invertPermutations(const qc::QuantumComputation& qc) {
-  return concat(invert(complete(qc.outputPermutation, qc.getNqubits())),
-                complete(qc.initialLayout, qc.getNqubits()));
+  return concat(invert(complete(qc.outputPermutation, qc.initialLayout)),
+                qc.initialLayout);
 }
 
 bool ZXEquivalenceChecker::fullReduceApproximate() {

--- a/test/python/test_verify.py
+++ b/test/python/test_verify.py
@@ -11,6 +11,7 @@
 from __future__ import annotations
 
 import pytest
+from mqt.core.ir import QuantumComputation
 from qiskit import transpile
 from qiskit.circuit import AncillaRegister, QuantumCircuit
 
@@ -128,3 +129,54 @@ def test_zx_ancilla_support() -> None:
         run_construction_checker=False,
     )
     assert result.equivalence == EquivalenceCriterion.no_information
+
+
+def test_issue_928() -> None:
+    """This is a regression test for the issue described in https://github.com/munich-quantum-toolkit/qcec/issues/928."""
+    qc1 = QuantumComputation.from_qasm_str("""
+OPENQASM 2.0;
+include "qelib1.inc";
+
+qreg q[8];
+creg m_c_7[1];
+
+id q[7];
+id q[0];
+id q[1];
+id q[2];
+id q[3];
+id q[4];
+id q[5];
+id q[6];
+measure q[7] -> m_c_7[0];
+id q[0];
+id q[1];
+id q[2];
+id q[3];
+id q[4];
+id q[5];
+id q[6];
+id q[7];
+""")
+
+    qc2 = QuantumComputation.from_qasm_str("""
+OPENQASM 2.0;
+include "qelib1.inc";
+
+qreg q[9];
+creg c[9];
+
+id q[0];
+id q[1];
+id q[2];
+id q[3];
+id q[4];
+id q[5];
+id q[6];
+id q[7];
+id q[8];
+cx q[7],q[8];
+""")
+
+    result = verify(qc1, qc2, transform_dynamic_circuit=True)
+    assert result.equivalence == EquivalenceCriterion.not_equivalent


### PR DESCRIPTION
## Description

`ec::complete(p, n)` in `ZXChecker.cpp` extended partial permutations by filling missing entries with synthetic indices from `[0, n)`, silently assuming the circuit's physical qubits were `{0, ..., n - 1}`. When optimizations leave non-contiguous physicals, `invertPermutations` dropped entries, and the subsequent `p.at(anc)` in `ZXEquivalenceChecker`'s ancilla setup threw `std::out_of_range`. Fixed by having `complete` take `qc.initialLayout` as a reference and fill missing entries using its actual physical keys and logical values.

AI notice: The bug was found and fixed by Claude Opus 4.7. I adapted its output for style. The summary above was also written by Claude Opus 4.7 and slightly adapted by me.

Fixes #928 

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] I have disclosed the use of AI tools in the PR description as per our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/qcec/blob/main/docs/ai_usage.md).
- [x] ~~AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.~~
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
