### PR TITLE
🔧 Set up `rumdl`

### DIFF
--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -3,8 +3,8 @@
 
 # Support
 
-If you are stuck with a problem using MQT QCEC or have questions, please get
-in touch at our [Issues] or [Discussions]. We'd love to help.
+If you are stuck with a problem using MQT QCEC or have questions, please get in
+touch at our [Issues] or [Discussions]. We'd love to help.
 
 You can save time by following this procedure when reporting a problem:
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -105,8 +105,18 @@ repos:
     rev: v3.9.1
     hooks:
       - id: prettier
-        types_or: [yaml, markdown, html, css, scss, javascript, json, json5]
+        types_or: [yaml, html, css, scss, javascript, json, json5]
         priority: 5
+
+    ## Format Markdown files with rumdl
+  - repo: https://github.com/rvben/rumdl-pre-commit
+    rev: v0.2.28
+    hooks:
+      - id: rumdl
+        args: [--fix]
+        priority: 5
+      - id: rumdl-fmt
+        priority: 6
 
   ## Format CMake files with cmake-format
   - repo: https://github.com/cheshirekow/cmake-format-precommit

--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -1,0 +1,20 @@
+[per-file-ignores]
+# The PR template is not a Markdown document in that sense
+"**/pull_request_template.md" = ["MD013", "MD041"]
+# The docs files may include HTML and do not need to start with a top-level heading
+"docs/**" = ["MD033", "MD041"]
+# The README may include HTML and does not need to start with a top-level heading
+"README.md" = ["MD033", "MD041"]
+
+[per-file-flavor]
+"docs/**" = "myst"
+
+[MD013]
+line-length = 80
+code-blocks = false
+headings = false
+reflow = true
+reflow-mode = "normalize"
+
+[MD060]
+enabled = true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,25 +5,34 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on a mixture of [Keep a Changelog] and [Common Changelog].
-This project adheres to [Semantic Versioning], with the exception that minor releases may include breaking changes.
+This project adheres to [Semantic Versioning], with the exception that minor
+releases may include breaking changes.
 
 ## [Unreleased]
 
 ### Added
 
-- 🚸 Add [CMake presets] to provide a standardized and reproducible way to configure builds ([#936]) ([**@denialhaag**])
+- 🚸 Add [CMake presets] to provide a standardized and reproducible way to
+  configure builds ([#936]) ([**@denialhaag**])
 
 ### Changed
 
 - ⬆️ Update `mqt-core` to version 3.7.0 ([#976]) ([**@denialhaag**])
 - ⬆️ Update `nanobind` to version 2.13.0 ([#976]) ([**@denialhaag**])
-- ⬆️ Update [munich-quantum-toolkit/workflows] to version `v2.0.1` ([#936]) ([**@denialhaag**])
+- ⬆️ Update [munich-quantum-toolkit/workflows] to version `v2.0.1` ([#936])
+  ([**@denialhaag**])
+
+### Removed
+
+- 📝 Remove support for generating LaTeX documentation ([#977])
+  ([**@denialhaag**])
 
 ## [3.6.1] - 2026-05-21
 
 ### Fixed
 
-- 🐛 Fix segfaults on permutation mismatches in the ZX checker ([#929]) ([**@denialhaag**])
+- 🐛 Fix segfaults on permutation mismatches in the ZX checker ([#929])
+  ([**@denialhaag**])
 
 ## [3.6.0] - 2026-05-13
 
@@ -31,7 +40,8 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#360)._
 
 ### Added
 
-- ✨ Add support for many multi-controlled gates to the ZX-calculus checker ([#907]) ([**@burgholzer**])
+- ✨ Add support for many multi-controlled gates to the ZX-calculus checker
+  ([#907]) ([**@burgholzer**])
 
 ### Changed
 
@@ -46,7 +56,8 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#350)._
 
 - ⬆️ Update `mqt-core` to version 3.4.1 ([#837]) ([**@denialhaag**])
 - ⬆️ Update `nanobind` to version 2.11.0 ([#837]) ([**@denialhaag**])
-- ♻️ Auto-generate `pyqcec.pyi` via `nanobind.stubgen` ([#831]) ([**@denialhaag**])
+- ♻️ Auto-generate `pyqcec.pyi` via `nanobind.stubgen` ([#831])
+  ([**@denialhaag**])
 - 🔧 Replace `mypy` with `ty` ([#775], [#825]) ([**@denialhaag**])
 
 ## [3.4.0] - 2026-01-13
@@ -55,13 +66,19 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#340)._
 
 ### Changed
 
-- ♻️ Migrate Python bindings from `pybind11` to `nanobind` ([#817]) ([**@denialhaag**])
+- ♻️ Migrate Python bindings from `pybind11` to `nanobind` ([#817])
+  ([**@denialhaag**])
 - 📦️ Provide Stable ABI wheels for Python 3.12+ ([#817]) ([**@denialhaag**])
-- ⬆️ Bump minimum required `mqt-core` version to `3.4.0` ([#817]) ([**@denialhaag**])
-- 👷 Stop testing on `ubuntu-22.04` and `ubuntu-22.04-arm` runners ([#796]) ([**@denialhaag**])
-- 👷 Stop testing with `clang-19` and start testing with `clang-21` ([#796]) ([**@denialhaag**])
-- 👷 Fix macOS tests with Homebrew Clang via new `munich-quantum-toolkit/workflows` version ([#796]) ([**@denialhaag**])
-- 👷 Re-enable macOS tests with GCC by disabling module scanning ([#796]) ([**@denialhaag**])
+- ⬆️ Bump minimum required `mqt-core` version to `3.4.0` ([#817])
+  ([**@denialhaag**])
+- 👷 Stop testing on `ubuntu-22.04` and `ubuntu-22.04-arm` runners ([#796])
+  ([**@denialhaag**])
+- 👷 Stop testing with `clang-19` and start testing with `clang-21` ([#796])
+  ([**@denialhaag**])
+- 👷 Fix macOS tests with Homebrew Clang via new
+  `munich-quantum-toolkit/workflows` version ([#796]) ([**@denialhaag**])
+- 👷 Re-enable macOS tests with GCC by disabling module scanning ([#796])
+  ([**@denialhaag**])
 
 ### Removed
 
@@ -77,7 +94,8 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#330)._
 
 ### Changed
 
-- ⬆️ Bump minimum required `mqt-core` version to `3.3.1` ([#735]) ([**@denialhaag**])
+- ⬆️ Bump minimum required `mqt-core` version to `3.3.1` ([#735])
+  ([**@denialhaag**])
 
 ### Removed
 
@@ -93,14 +111,18 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#320)._
 
 ### Changed
 
-- ⬆️ Bump minimum required `mqt-core` version to `3.2.1` ([#668]) ([**@denialhaag**])
-- ⬆️ Bump minimum required `mqt-core` version to `3.2.0` ([#667]) ([**@denialhaag**])
+- ⬆️ Bump minimum required `mqt-core` version to `3.2.1` ([#668])
+  ([**@denialhaag**])
+- ⬆️ Bump minimum required `mqt-core` version to `3.2.0` ([#667])
+  ([**@denialhaag**])
 - ⬆️ Require C++20 ([#667]) ([**@denialhaag**])
-- ✨ Expose enums to Python via `pybind11`'s new (`enum.Enum`-compatible) `py::native_enum` ([#663]) ([**@denialhaag**])
+- ✨ Expose enums to Python via `pybind11`'s new (`enum.Enum`-compatible)
+  `py::native_enum` ([#663]) ([**@denialhaag**])
 
 ### Fixed
 
-- 🚸 Increase binary compatibility between `mqt-qcec` and `mqt-core` ([#662]) ([**@denialhaag**])
+- 🚸 Increase binary compatibility between `mqt-qcec` and `mqt-core` ([#662])
+  ([**@denialhaag**])
 
 ## [3.1.0] - 2025-07-11
 
@@ -108,19 +130,26 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#310)._
 
 ### Changed
 
-- ⬆️ Bump minimum required `mqt-core` version to `3.1.0` ([#646]) ([**@denialhaag**])
-- ⬆️ Bump minimum required `pybind11` version to `3.0.0` ([#646]) ([**@denialhaag**])
-- ♻️ Move the C++ code for the Python bindings to the top-level `bindings` directory ([#618]) ([**@denialhaag**])
-- ♻️ Move all Python code (no tests) to the top-level `python` directory ([#618]) ([**@denialhaag**])
-- 💥 ZX-calculus checker now reports that it can't handle circuits with non-garbage ancilla qubits ([#512]) ([**@pehamTom**])
+- ⬆️ Bump minimum required `mqt-core` version to `3.1.0` ([#646])
+  ([**@denialhaag**])
+- ⬆️ Bump minimum required `pybind11` version to `3.0.0` ([#646])
+  ([**@denialhaag**])
+- ♻️ Move the C++ code for the Python bindings to the top-level `bindings`
+  directory ([#618]) ([**@denialhaag**])
+- ♻️ Move all Python code (no tests) to the top-level `python` directory
+  ([#618]) ([**@denialhaag**])
+- 💥 ZX-calculus checker now reports that it can't handle circuits with
+  non-garbage ancilla qubits ([#512]) ([**@pehamTom**])
 
 ### Deprecated
 
-- 🗑️ Deprecate the `mode` argument of `generate_profile()` and the `ancilla_mode` argument of `verify_compilation()` ([#626]) ([**@denialhaag**])
+- 🗑️ Deprecate the `mode` argument of `generate_profile()` and the
+  `ancilla_mode` argument of `verify_compilation()` ([#626]) ([**@denialhaag**])
 
 ### Fixed
 
-- 🐛 Fix bug in ZX-calculus checker for circuits without data qubits ([#512]) ([**@pehamTom**])
+- 🐛 Fix bug in ZX-calculus checker for circuits without data qubits ([#512])
+  ([**@pehamTom**])
 
 ## [3.0.0] - 2025-05-05
 
@@ -133,16 +162,22 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#300)._
 ### Changed
 
 - 🚚 Move MQT QCEC to the [munich-quantum-toolkit] GitHub organization
-- ♻️ Use the `mqt-core` Python package for handling circuits ([#432]) ([**@burgholzer**])
-- ♻️ Return counterexamples as decision diagrams instead of dense arrays ([#566]) ([**@burgholzer**])
-- ♻️ Reduce and restructure public interface of the `EquivalenceCheckingManager` ([#566]) ([**@burgholzer**])
-- ⬆️ Bump minimum required CMake version to `3.24.0` ([#582]) ([**@burgholzer**])
+- ♻️ Use the `mqt-core` Python package for handling circuits ([#432])
+  ([**@burgholzer**])
+- ♻️ Return counterexamples as decision diagrams instead of dense arrays
+  ([#566]) ([**@burgholzer**])
+- ♻️ Reduce and restructure public interface of the `EquivalenceCheckingManager`
+  ([#566]) ([**@burgholzer**])
+- ⬆️ Bump minimum required CMake version to `3.24.0` ([#582])
+  ([**@burgholzer**])
 - 📝 Rework existing project documentation ([#566]) ([**@burgholzer**])
 
 ### Removed
 
-- 🔥 Remove support for `.real`, `.qc`, `.tfc`, and `GRCS` files ([#582]) ([**@burgholzer**])
-- 🔥 Remove several re-exports from the top-level `mqt-qcec` package ([#566]) ([**@burgholzer**])
+- 🔥 Remove support for `.real`, `.qc`, `.tfc`, and `GRCS` files ([#582])
+  ([**@burgholzer**])
+- 🔥 Remove several re-exports from the top-level `mqt-qcec` package ([#566])
+  ([**@burgholzer**])
 
 ## [2.8.2] - 2025-02-18
 
@@ -163,6 +198,7 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 
 <!-- PR links -->
 
+[#977]: https://github.com/munich-quantum-toolkit/qcec/pull/977
 [#976]: https://github.com/munich-quantum-toolkit/qcec/pull/976
 [#936]: https://github.com/munich-quantum-toolkit/qcec/pull/936
 [#929]: https://github.com/munich-quantum-toolkit/qcec/pull/929
@@ -176,7 +212,6 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 [#735]: https://github.com/munich-quantum-toolkit/qcec/pull/735
 [#730]: https://github.com/munich-quantum-toolkit/qcec/pull/730
 [#704]: https://github.com/munich-quantum-toolkit/qcec/pull/704
-[#699]: https://github.com/munich-quantum-toolkit/qcec/pull/699
 [#668]: https://github.com/munich-quantum-toolkit/qcec/pull/668
 [#667]: https://github.com/munich-quantum-toolkit/qcec/pull/667
 [#665]: https://github.com/munich-quantum-toolkit/qcec/pull/663

--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@
 
 # MQT QCEC - A tool for Quantum Circuit Equivalence Checking
 
-A tool for quantum circuit equivalence checking developed as part of the [_Munich Quantum Toolkit (MQT)_](https://mqt.readthedocs.io).
-It builds upon [MQT Core](https://github.com/munich-quantum-toolkit/core), which forms the backbone of the MQT.
+A tool for quantum circuit equivalence checking developed as part of the
+[_Munich Quantum Toolkit (MQT)_](https://mqt.readthedocs.io). It builds upon
+[MQT Core](https://github.com/munich-quantum-toolkit/core), which forms the
+backbone of the MQT.
 
 <p align="center">
   <a href="https://mqt.readthedocs.io/projects/qcec">
@@ -28,19 +30,45 @@ It builds upon [MQT Core](https://github.com/munich-quantum-toolkit/core), which
 
 ## Key Features
 
-- Comprehensive equivalence checking engines: [Decision-diagram construction](https://mqt.readthedocs.io/projects/qcec/en/latest/equivalence_checking.html#construction-equivalence-checker-using-decision-diagrams), [Alternating DD](https://mqt.readthedocs.io/projects/qcec/en/latest/equivalence_checking.html#alternating-equivalence-checker-using-decision-diagrams), [Simulation-based falsification](https://mqt.readthedocs.io/projects/qcec/en/latest/equivalence_checking.html#simulation-equivalence-checker-using-decision-diagrams), and [ZX-calculus rewriting](https://mqt.readthedocs.io/projects/qcec/en/latest/equivalence_checking.html#zx-calculus-equivalence-checker)—coordinated in an automated [equivalence checking flow](https://mqt.readthedocs.io/projects/qcec/en/latest/equivalence_checking.html#resulting-equivalence-checking-flow) to prove equivalence or quickly find counterexamples.
-- Compilation flow verification: validate transpiled/compiled circuits incl. layout permutations and measurements. [Guide](https://mqt.readthedocs.io/projects/qcec/en/latest/compilation_flow_verification.html)
-- Parameterized circuits: prove or refute equivalence with symbolic parameters. [Guide](https://mqt.readthedocs.io/projects/qcec/en/latest/parametrized_circuits.html)
-- Partial equivalence: compare measured output distributions, handling ancillary and garbage qubits. [Guide](https://mqt.readthedocs.io/projects/qcec/en/latest/partial_equivalence.html)
-- Python-first API and Qiskit integration: pass `QuantumCircuit` or OpenQASM; one-call `verify()` or `verify_compilation()`. [Quickstart](https://mqt.readthedocs.io/projects/qcec/en/latest/quickstart.html) • [API](https://mqt.readthedocs.io/projects/qcec/en/latest/api/mqt/qcec/index.html)
-- Efficient and portable: C++20 core with DD engines and ZX backend, prebuilt wheels for Linux/macOS/Windows via [PyPI](https://pypi.org/project/mqt.qcec/).
+- Comprehensive equivalence checking engines:
+  [Decision-diagram construction](https://mqt.readthedocs.io/projects/qcec/en/latest/equivalence_checking.html#construction-equivalence-checker-using-decision-diagrams),
+  [Alternating DD](https://mqt.readthedocs.io/projects/qcec/en/latest/equivalence_checking.html#alternating-equivalence-checker-using-decision-diagrams),
+  [Simulation-based falsification](https://mqt.readthedocs.io/projects/qcec/en/latest/equivalence_checking.html#simulation-equivalence-checker-using-decision-diagrams),
+  and
+  [ZX-calculus rewriting](https://mqt.readthedocs.io/projects/qcec/en/latest/equivalence_checking.html#zx-calculus-equivalence-checker)—coordinated
+  in an automated
+  [equivalence checking flow](https://mqt.readthedocs.io/projects/qcec/en/latest/equivalence_checking.html#resulting-equivalence-checking-flow)
+  to prove equivalence or quickly find counterexamples.
+- Compilation flow verification: validate transpiled/compiled circuits incl.
+  layout permutations and measurements.
+  [Guide](https://mqt.readthedocs.io/projects/qcec/en/latest/compilation_flow_verification.html)
+- Parameterized circuits: prove or refute equivalence with symbolic parameters.
+  [Guide](https://mqt.readthedocs.io/projects/qcec/en/latest/parametrized_circuits.html)
+- Partial equivalence: compare measured output distributions, handling ancillary
+  and garbage qubits.
+  [Guide](https://mqt.readthedocs.io/projects/qcec/en/latest/partial_equivalence.html)
+- Python-first API and Qiskit integration: pass `QuantumCircuit` or OpenQASM;
+  one-call `verify()` or `verify_compilation()`.
+  [Quickstart](https://mqt.readthedocs.io/projects/qcec/en/latest/quickstart.html)
+  •
+  [API](https://mqt.readthedocs.io/projects/qcec/en/latest/api/mqt/qcec/index.html)
+- Efficient and portable: C++20 core with DD engines and ZX backend, prebuilt
+  wheels for Linux/macOS/Windows via [PyPI](https://pypi.org/project/mqt.qcec/).
 
-If you have any questions, feel free to create a [discussion](https://github.com/munich-quantum-toolkit/qcec/discussions) or an [issue](https://github.com/munich-quantum-toolkit/qcec/issues) on [GitHub](https://github.com/munich-quantum-toolkit/qcec).
+If you have any questions, feel free to create a
+[discussion](https://github.com/munich-quantum-toolkit/qcec/discussions) or an
+[issue](https://github.com/munich-quantum-toolkit/qcec/issues) on
+[GitHub](https://github.com/munich-quantum-toolkit/qcec).
 
 ## Contributors and Supporters
 
-The _[Munich Quantum Toolkit (MQT)](https://mqt.readthedocs.io)_ is developed by the [Chair for Design Automation](https://www.cda.cit.tum.de/) at the [Technical University of Munich](https://www.tum.de/) and supported by [MQSC](https://mq.sc).
-Among others, it is part of the [Munich Quantum Software Stack (MQSS)](https://www.munich-quantum-valley.de/research/research-areas/mqss) ecosystem, which is being developed as part of the [Munich Quantum Valley (MQV)](https://www.munich-quantum-valley.de) initiative.
+The _[Munich Quantum Toolkit (MQT)](https://mqt.readthedocs.io)_ is developed by
+the [Chair for Design Automation](https://www.cda.cit.tum.de/) at the
+[Technical University of Munich](https://www.tum.de/) and supported by
+[MQSC](https://mq.sc). Among others, it is part of the
+[Munich Quantum Software Stack (MQSS)](https://www.munich-quantum-valley.de/research/research-areas/mqss)
+ecosystem, which is being developed as part of the
+[Munich Quantum Valley (MQV)](https://www.munich-quantum-valley.de) initiative.
 
 <p align="center">
   <picture>
@@ -57,17 +85,21 @@ Thank you to all the contributors who have helped make MQT QCEC a reality!
   </a>
 </p>
 
-The MQT will remain free, open-source, and permissively licensed—now and in the future.
-We are firmly committed to keeping it open and actively maintained for the quantum computing community.
+The MQT will remain free, open-source, and permissively licensed—now and in the
+future. We are firmly committed to keeping it open and actively maintained for
+the quantum computing community.
 
 To support this endeavor, please consider:
 
-- Starring and sharing our repositories: https://github.com/munich-quantum-toolkit
-- Contributing code, documentation, tests, or examples via issues and pull requests
+- Starring and sharing our repositories:
+  <https://github.com/munich-quantum-toolkit>
+- Contributing code, documentation, tests, or examples via issues and pull
+  requests
 - Citing the MQT in your publications (see [Cite This](#cite-this))
-- Citing our research in your publications (see [References](https://mqt.readthedocs.io/projects/qcec/en/latest/references.html))
+- Citing our research in your publications (see
+  [References](https://mqt.readthedocs.io/projects/qcec/en/latest/references.html))
 - Using the MQT in research and teaching, and sharing feedback and use cases
-- Sponsoring us on GitHub: https://github.com/sponsors/munich-quantum-toolkit
+- Sponsoring us on GitHub: <https://github.com/sponsors/munich-quantum-toolkit>
 
 <p align="center">
   <a href="https://github.com/sponsors/munich-quantum-toolkit">
@@ -80,7 +112,7 @@ To support this endeavor, please consider:
 MQT QCEC is available via [PyPI](https://pypi.org/project/mqt.qcec/).
 
 ```console
-(venv) $ pip install mqt.qcec
+uv pip install mqt.qcec
 ```
 
 The following code gives an example on the usage:
@@ -95,14 +127,18 @@ result = qcec.verify("circ1.qasm", "circ2.qasm")
 print(result.equivalence)
 ```
 
-**Detailed documentation and examples are available at [ReadTheDocs](https://mqt.readthedocs.io/projects/qcec).**
+**Detailed documentation and examples are available at
+[ReadTheDocs](https://mqt.readthedocs.io/projects/qcec).**
 
 ## System Requirements and Building
 
-Building the project requires a C++ compiler with support for C++20 and CMake 3.24 or newer.
-For details on how to build the project, please refer to the [documentation](https://mqt.readthedocs.io/projects/qcec).
-Building (and running) is continuously tested under Linux, macOS, and Windows using the [latest available system versions for GitHub Actions](https://github.com/actions/runner-images).
-MQT QCEC is compatible with all [officially supported Python versions](https://devguide.python.org/versions/).
+Building the project requires a C++ compiler with support for C++20 and CMake
+3.24 or newer. For details on how to build the project, please refer to the
+[documentation](https://mqt.readthedocs.io/projects/qcec). Building (and
+running) is continuously tested under Linux, macOS, and Windows using the
+[latest available system versions for GitHub Actions](https://github.com/actions/runner-images).
+MQT QCEC is compatible with all
+[officially supported Python versions](https://devguide.python.org/versions/).
 
 ## Cite This
 
@@ -110,7 +146,8 @@ Please cite the work that best fits your use case.
 
 ### MQT QCEC (the tool)
 
-When citing the software itself or results produced with it, cite the MQT QCEC paper:
+When citing the software itself or results produced with it, cite the MQT QCEC
+paper:
 
 ```bibtex
 @article{burgholzerQCECJKQTool2021,
@@ -143,25 +180,46 @@ When discussing the overall MQT project or its ecosystem, cite the MQT Handbook:
 
 ### Peer-Reviewed Research
 
-When citing the underlying methods and research, please reference the most relevant peer-reviewed publications from the list below:
+When citing the underlying methods and research, please reference the most
+relevant peer-reviewed publications from the list below:
 
-[[1]](https://arxiv.org/pdf/2004.08420.pdf) L. Burgholzer and R. Wille. Advanced Equivalence Checking for Quantum Circuits. _IEEE Transactions on Computer-Aided Design of Integrated Circuits and Systems (TCAD)_, 2021.
+[[1]](https://arxiv.org/pdf/2004.08420.pdf) L. Burgholzer and R. Wille. Advanced
+Equivalence Checking for Quantum Circuits. _IEEE Transactions on Computer-Aided
+Design of Integrated Circuits and Systems (TCAD)_, 2021.
 
-[[2]](https://arxiv.org/pdf/2009.02376.pdf) L. Burgholzer, R. Raymond, and R. Wille. Verifying Results of the IBM Qiskit Quantum Circuit Compilation Flow. In _IEEE International Conference on Quantum Computing and Engineering (QCE)_, 2020.
+[[2]](https://arxiv.org/pdf/2009.02376.pdf) L. Burgholzer, R. Raymond, and R.
+Wille. Verifying Results of the IBM Qiskit Quantum Circuit Compilation Flow. In
+_IEEE International Conference on Quantum Computing and Engineering (QCE)_,
+2020.
 
-[[3]](https://arxiv.org/pdf/2011.07288.pdf) L. Burgholzer, R. Kueng, and R. Wille. Random Stimuli Generation for the Verification of Quantum Circuits. In _Asia and South Pacific Design Automation Conference (ASP-DAC)_, 2021.
+[[3]](https://arxiv.org/pdf/2011.07288.pdf) L. Burgholzer, R. Kueng, and R.
+Wille. Random Stimuli Generation for the Verification of Quantum Circuits. In
+_Asia and South Pacific Design Automation Conference (ASP-DAC)_, 2021.
 
-[[4]](https://arxiv.org/pdf/2106.01099.pdf) L. Burgholzer and R. Wille. Handling Non-Unitaries in Quantum Circuit Equivalence Checking. In _Design Automation Conference (DAC)_, 2022.
+[[4]](https://arxiv.org/pdf/2106.01099.pdf) L. Burgholzer and R. Wille. Handling
+Non-Unitaries in Quantum Circuit Equivalence Checking. In
+_Design Automation Conference (DAC)_, 2022.
 
-[[5]](https://arxiv.org/pdf/2208.12820.pdf) T. Peham, L. Burgholzer, and R. Wille. Equivalence Checking of Quantum Circuits with the ZX-Calculus. _IEEE Journal on Emerging and Selected Topics in Circuits and Systems (JETCAS)_, 2022.
+[[5]](https://arxiv.org/pdf/2208.12820.pdf) T. Peham, L. Burgholzer, and R.
+Wille. Equivalence Checking of Quantum Circuits with the ZX-Calculus.
+_IEEE Journal on Emerging and Selected Topics in Circuits and Systems (JETCAS)_,
+2022.
 
-[[6]](https://arxiv.org/pdf/2210.12166.pdf) T. Peham, L. Burgholzer, and R. Wille. Equivalence Checking of Parameterized Quantum Circuits: Verifying the Compilation of Variational Quantum Algorithms. In _Asia and South Pacific Design Automation Conference (ASP-DAC)_, 2023.
+[[6]](https://arxiv.org/pdf/2210.12166.pdf) T. Peham, L. Burgholzer, and R.
+Wille. Equivalence Checking of Parameterized Quantum Circuits: Verifying the
+Compilation of Variational Quantum Algorithms. In
+_Asia and South Pacific Design Automation Conference (ASP-DAC)_, 2023.
 
 ---
 
 ## Acknowledgements
 
-The Munich Quantum Toolkit has been supported by the European Research Council (ERC) under the European Union's Horizon 2020 research and innovation program (grant agreement No. 101001318), the Bavarian State Ministry for Science and Arts through the Distinguished Professorship Program, as well as the Munich Quantum Valley, which is supported by the Bavarian state government with funds from the Hightech Agenda Bayern Plus.
+The Munich Quantum Toolkit has been supported by the European Research Council
+(ERC) under the European Union's Horizon 2020 research and innovation program
+(grant agreement No. 101001318), the Bavarian State Ministry for Science and
+Arts through the Distinguished Professorship Program, as well as the Munich
+Quantum Valley, which is supported by the Bavarian state government with funds
+from the Hightech Agenda Bayern Plus.
 
 <p align="center">
   <picture>

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,17 +1,22 @@
 # Upgrade Guide
 
-This document describes breaking changes and how to upgrade. For a complete list of changes including minor and patch releases, please refer to the [changelog](CHANGELOG.md).
+This document describes breaking changes and how to upgrade. For a complete list
+of changes including minor and patch releases, please refer to the
+[changelog](CHANGELOG.md).
 
 ## [Unreleased]
 
-This release updates the minimum required `mqt-core` version to 3.7.0 as well as the `nanobind` version to 2.13.0.
+This release updates the minimum required `mqt-core` version to 3.7.0 as well as
+the `nanobind` version to 2.13.0.
 
 ### CMake presets
 
-[CMake presets] have been added to provide a standardized and reproducible way to configure builds across different platforms.
-These presets are also used in our CI.
+[CMake presets] have been added to provide a standardized and reproducible way
+to configure builds across different platforms. These presets are also used in
+our CI.
 
-On Unix systems, the `debug`, `release`, and `coverage` presets can be used to configure, build, and test MQT QCEC.
+On Unix systems, the `debug`, `release`, and `coverage` presets can be used to
+configure, build, and test MQT QCEC.
 
 ```console
 cmake --preset release
@@ -19,21 +24,28 @@ cmake --build --preset release
 ctest --preset release
 ```
 
-Additionally, the `lint` preset can be used to configure and build MQT QCEC in preparation for a `clang-tidy` run.
+Additionally, the `lint` preset can be used to configure and build MQT QCEC in
+preparation for a `clang-tidy` run.
 
 If you are on Windows, use the `debug-windows` and `release-windows` presets.
 
 ## [3.6.0]
 
-This release brings extended support for multi-controlled gates that was introduced in https://github.com/munich-quantum-toolkit/core/pull/1380 to the ZX-calculus checker.
+This release brings extended support for multi-controlled gates that was
+introduced in <https://github.com/munich-quantum-toolkit/core/pull/1380> to the
+ZX-calculus checker.
 
-This release also updates the minimum required `mqt-core` version to 3.6.0 as well as the `nanobind` version to 2.12.0.
+This release also updates the minimum required `mqt-core` version to 3.6.0 as
+well as the `nanobind` version to 2.12.0.
 
 ## [3.5.0]
 
-To comply with established guidelines for attribute names, `mqt.qcec.pyqcec.StateType.random_1Q_basis` has been renamed to `random_1q_basis`.
+To comply with established guidelines for attribute names,
+`mqt.qcec.pyqcec.StateType.random_1Q_basis` has been renamed to
+`random_1q_basis`.
 
-This release also updates the minimum required `mqt-core` version to 3.4.1 as well as the `nanobind` version to 2.11.0.
+This release also updates the minimum required `mqt-core` version to 3.4.1 as
+well as the `nanobind` version to 2.11.0.
 
 ## [3.4.0]
 
@@ -41,15 +53,16 @@ This release also updates the minimum required `mqt-core` version to 3.4.1 as we
 
 This release contains two changes to the distributed wheels.
 
-First, we have removed all wheels for Python 3.13t.
-Free-threading Python was introduced as an experimental feature in Python 3.13.
-It became stable in Python 3.14.
+First, we have removed all wheels for Python 3.13t. Free-threading Python was
+introduced as an experimental feature in Python 3.13. It became stable in Python
+3.14.
 
-Second, for Python 3.12+, we are now providing Stable ABI wheels instead of separate version-specific wheels.
-This was enabled by migrating our Python bindings from `pybind11` to `nanobind`.
+Second, for Python 3.12+, we are now providing Stable ABI wheels instead of
+separate version-specific wheels. This was enabled by migrating our Python
+bindings from `pybind11` to `nanobind`.
 
-Both of these changes were made in the interest of conserving PyPI space and reducing CI/CD build times.
-The full list of wheels now reads:
+Both of these changes were made in the interest of conserving PyPI space and
+reducing CI/CD build times. The full list of wheels now reads:
 
 - 3.10
 - 3.11
@@ -60,59 +73,81 @@ The full list of wheels now reads:
 
 ### End of support for Python 3.9
 
-Starting with this release, MQT QCEC no longer supports Python 3.9.
-This is in line with the scheduled end of life of the version.
-As a result, MQT QCEC is no longer tested under Python 3.9 and no longer ships Python 3.9 wheels.
+Starting with this release, MQT QCEC no longer supports Python 3.9. This is in
+line with the scheduled end of life of the version. As a result, MQT QCEC is no
+longer tested under Python 3.9 and no longer ships Python 3.9 wheels.
 
 ## [3.2.0]
 
-Testing previous versions of the `mqt-qcec` package built via `uv sync` or simple `(uv) pip install .` generally failed due to binary incompatibility of the `mqt-core` compiled extension packages and the `mqt-qcec` one.
-This required building `mqt-core` from source and without build isolation to get a working local setup.
-By using the latest `pybind11` release (`v3`), the binary compatibility between extension modules compiled under different circumstances (such as different compilers) has been greatly increased.
-As such, it is no longer necessary to build `mqt-core` from source and without build isolation when locally working on `mqt-qcec`.
-A simple `uv sync` is enough to successfully run `pytest`.
+Testing previous versions of the `mqt-qcec` package built via `uv sync` or
+simple `(uv) pip install .` generally failed due to binary incompatibility of
+the `mqt-core` compiled extension packages and the `mqt-qcec` one. This required
+building `mqt-core` from source and without build isolation to get a working
+local setup. By using the latest `pybind11` release (`v3`), the binary
+compatibility between extension modules compiled under different circumstances
+(such as different compilers) has been greatly increased. As such, it is no
+longer necessary to build `mqt-core` from source and without build isolation
+when locally working on `mqt-qcec`. A simple `uv sync` is enough to successfully
+run `pytest`.
 
-The `ApplicationScheme`, `EquivalenceCriterion`, and `StateType` enums are now exposed via `pybind11`'s new `py::native_enum`, which makes them compatible with Python's `enum.Enum` class (PEP 435).
-As a result, the enums can no longer be initialized using a string.
-Instead of `ApplicationScheme("sequential")` or `"sequential"`, use `ApplicationScheme.sequential`.
+The `ApplicationScheme`, `EquivalenceCriterion`, and `StateType` enums are now
+exposed via `pybind11`'s new `py::native_enum`, which makes them compatible with
+Python's `enum.Enum` class (PEP 435). As a result, the enums can no longer be
+initialized using a string. Instead of `ApplicationScheme("sequential")` or
+`"sequential"`, use `ApplicationScheme.sequential`.
 
 Finally, the minimum required C++ version has been raised from C++17 to C++20.
-The default compilers of our test systems support all relevant features of the standard.
+The default compilers of our test systems support all relevant features of the
+standard.
 
 ## [3.1.0]
 
-Even tough this is not a breaking change, it is worth mentioning to developers of MQT QCEC that all Python code (except tests) has been moved to the top-level `python` directory.
-Furthermore, the C++ code for the Python bindings has been moved to the top-level `bindings` directory.
+Even tough this is not a breaking change, it is worth mentioning to developers
+of MQT QCEC that all Python code (except tests) has been moved to the top-level
+`python` directory. Furthermore, the C++ code for the Python bindings has been
+moved to the top-level `bindings` directory.
 
 ## [3.0.0]
 
-This major release introduces several breaking changes, including the removal of deprecated features and the introduction of new APIs.
-The following paragraphs describe the most important changes and how to adapt your code accordingly.
-We intend to provide a more comprehensive migration guide for future releases.
+This major release introduces several breaking changes, including the removal of
+deprecated features and the introduction of new APIs. The following paragraphs
+describe the most important changes and how to adapt your code accordingly. We
+intend to provide a more comprehensive migration guide for future releases.
 
-The major change in this major release is the move to the MQT Core Python package.
-This move allows us to make `qiskit` a fully optional dependency and entirely rely on the MQT Core IR for representing circuits.
-Additionally, the `mqt-core` Python package now ships all its C++ libraries as shared libraries so that these need not be fetched or built as part of the build process.
-This was tricky to achieve cross-platform, and you can find some more backstory in the corresponding [PR](https://github.com/munich-quantum-toolkit/qcec/pulls/432).
-We expect this integration to mature over the next few releases.
-If you encounter any issues, please let us know.
+The major change in this major release is the move to the MQT Core Python
+package. This move allows us to make `qiskit` a fully optional dependency and
+entirely rely on the MQT Core IR for representing circuits. Additionally, the
+`mqt-core` Python package now ships all its C++ libraries as shared libraries so
+that these need not be fetched or built as part of the build process. This was
+tricky to achieve cross-platform, and you can find some more backstory in the
+corresponding [PR](https://github.com/munich-quantum-toolkit/qcec/pulls/432). We
+expect this integration to mature over the next few releases. If you encounter
+any issues, please let us know.
 
-Some internals of QCEC have been streamlined and refactored to improve the overall code quality and maintainability.
-Most notably, counterexamples are now returned as decision diagrams instead of dense arrays.
-This was made possible by the move to the MQT Core Python package, which now also exposes the underlying DD package to Python.
-The returned DDs have a [`get_vector()`](https://mqt.readthedocs.io/projects/core/en/v3.0.2/api/mqt/core/dd/#mqt.core.dd.VectorDD.get_vector) method that can be used to convert them to a dense array if needed.
+Some internals of QCEC have been streamlined and refactored to improve the
+overall code quality and maintainability. Most notably, counterexamples are now
+returned as decision diagrams instead of dense arrays. This was made possible by
+the move to the MQT Core Python package, which now also exposes the underlying
+DD package to Python. The returned DDs have a
+[`get_vector()`](https://mqt.readthedocs.io/projects/core/en/v3.0.2/api/mqt/core/dd/#mqt.core.dd.VectorDD.get_vector)
+method that can be used to convert them to a dense array if needed.
 
-MQT Core itself dropped support for several parsers in `v3.0.0`, including the `.real`, `.qc`, `.tfc`, and `GRCS` parsers.
-The `.real` parser lives on as part of the [MQT SyReC] project. All others have been removed without replacement.
+MQT Core itself dropped support for several parsers in `v3.0.0`, including the
+`.real`, `.qc`, `.tfc`, and `GRCS` parsers. The `.real` parser lives on as part
+of the [MQT SyReC] project. All others have been removed without replacement.
 Consequently, these input formats are no longer supported in MQT QCEC.
 
-MQT QCEC has moved to the [munich-quantum-toolkit](https://github.com/munich-quantum-toolkit) GitHub organization under https://github.com/munich-quantum-toolkit/qcec.
-While most links should be automatically redirected, please update any links in your code to point to the new location.
-All links in the documentation have been updated accordingly.
+MQT QCEC has moved to the
+[munich-quantum-toolkit](https://github.com/munich-quantum-toolkit) GitHub
+organization under <https://github.com/munich-quantum-toolkit/qcec>. While most
+links should be automatically redirected, please update any links in your code
+to point to the new location. All links in the documentation have been updated
+accordingly.
 
-MQT QCEC now requires CMake 3.24 or higher.
-Most modern operating systems should have this version available in their package manager.
-Alternatively, CMake can be conveniently installed from PyPI using the [`cmake`](https://pypi.org/project/cmake/) package.
+MQT QCEC now requires CMake 3.24 or higher. Most modern operating systems should
+have this version available in their package manager. Alternatively, CMake can
+be conveniently installed from PyPI using the
+[`cmake`](https://pypi.org/project/cmake/) package.
 
 <!-- Version links -->
 

--- a/docs/compilation_flow_verification.md
+++ b/docs/compilation_flow_verification.md
@@ -10,29 +10,47 @@ mystnb:
 
 ## Quantum Circuit Compilation
 
-Initially, quantum algorithms are described in a way which is agnostic of the device they are planned to be executed on.
-However, physical devices today impose several constraints on the circuits to be executed:
+Initially, quantum algorithms are described in a way which is agnostic of the
+device they are planned to be executed on. However, physical devices today
+impose several constraints on the circuits to be executed:
 
-1. **Limited gate-set:** Typically, only a small set of gates is natively supported by devices, e.g., consisting of arbitrary single-qubit gates and the two-qubit CNOT operation.
+1. **Limited gate-set:** Typically, only a small set of gates is natively
+   supported by devices, e.g., consisting of arbitrary single-qubit gates and
+   the two-qubit CNOT operation.
 
-2. **Limited connectivity:** Devices frequently limit the pairs of qubits that operations may be applied to. This is usually described by a coupling graph, where the graph's nodes represent the qubits and an edge between two nodes indicates that a CNOT operation may be applied to those qubits.
+2. **Limited connectivity:** Devices frequently limit the pairs of qubits that
+   operations may be applied to. This is usually described by a coupling graph,
+   where the graph's nodes represent the qubits and an edge between two nodes
+   indicates that a CNOT operation may be applied to those qubits.
 
-3. **Short coherence times and limited fidelity:** A device's physical qubits are inherently affected by noise. Until a certain threshold concerning the number of available qubits is reached, error correction is not yet an option.
+3. **Short coherence times and limited fidelity:** A device's physical qubits
+   are inherently affected by noise. Until a certain threshold concerning the
+   number of available qubits is reached, error correction is not yet an option.
 
-The first two, i.e., the limited gate-set and connectivity, constitute hard constraints---a computation not conforming to these restrictions may not be executed on the device.
-In contrast, the short coherence time and limited gate fidelity represent soft constraints---a quantum circuit may be executed on a device, but it is not guaranteed to produce meaningful results if the circuit, e.g., is too large for the state to stay coherent.
+The first two, i.e., the limited gate-set and connectivity, constitute hard
+constraints---a computation not conforming to these restrictions may not be
+executed on the device. In contrast, the short coherence time and limited gate
+fidelity represent soft constraints---a quantum circuit may be executed on a
+device, but it is not guaranteed to produce meaningful results if the circuit,
+e.g., is too large for the state to stay coherent.
 
-Just as in classical computing, a conceptual algorithm needs to be compiled to the targeted architecture to address these constraints.
-Throughout the compilation process, the gates and the structure of the underlying circuit is changed considerably.
-The following figure exemplary illustrates the compilation of a 3-qubit circuit implementing the Grover search algorithm to the 5-qubit IBMQ London architecture.
+Just as in classical computing, a conceptual algorithm needs to be compiled to
+the targeted architecture to address these constraints. Throughout the
+compilation process, the gates and the structure of the underlying circuit is
+changed considerably. The following figure exemplary illustrates the compilation
+of a 3-qubit circuit implementing the Grover search algorithm to the 5-qubit
+IBMQ London architecture.
 
 ```{image} images/compilation_flow.png
 :width: 100%
 :alt: Compilation of a quantum circuit
 ```
 
-It is of utmost importance that, after compilation, the resulting (compiled) circuit still implements the same functionality as the originally given circuit.
-This can be guaranteed by verifying the results of the compilation flow, i.e., checking the equivalence of the original circuit description with the compiled quantum circuit.
+It is of utmost importance that, after compilation, the resulting (compiled)
+circuit still implements the same functionality as the originally given circuit.
+This can be guaranteed by verifying the results of the compilation flow, i.e.,
+checking the equivalence of the original circuit description with the compiled
+quantum circuit.
 
 ## Using QCEC to Verify Compilation Flow Results
 
@@ -57,9 +75,13 @@ circ.draw(output="mpl", style="iqp")
 ```
 
 ```{note}
-It is essential to include measurements at the end of the circuit, since the equivalence checker uses the measurements to determine the final location of the logical qubits in the compiled circuit.
-Failing to do so may result in incorrect results because the checker will then simply assume that the logical qubits are mapped to the physical qubits in the same order as they appear in the circuit.
-Make sure to insert measurements *before* the circuit is compiled to the target architecture.
+It is essential to include measurements at the end of the circuit, since the
+equivalence checker uses the measurements to determine the final location of the
+logical qubits in the compiled circuit. Failing to do so may result in incorrect
+results because the checker will then simply assume that the logical qubits are
+mapped to the physical qubits in the same order as they appear in the circuit.
+Make sure to insert measurements *before* the circuit is compiled to the target
+architecture.
 ```
 
 Then, compile the circuit to the desired target architecture.
@@ -77,7 +99,8 @@ circ_comp = transpile(circ, backend=backend, optimization_level=optimization_lev
 circ_comp.draw(output="mpl", fold=-1, style="iqp")
 ```
 
-Then, using QCEC to verify that the circuit has been compiled correctly is as easy as
+Then, using QCEC to verify that the circuit has been compiled correctly is as
+easy as
 
 ```{code-cell} ipython3
 from mqt import qcec
@@ -86,4 +109,5 @@ results = qcec.verify_compilation(circ, circ_comp, optimization_level=optimizati
 results.equivalence
 ```
 
-Check out the {py:func}`reference documentation <.verify_compilation>` for more information.
+Check out the {py:func}`reference documentation <.verify_compilation>` for more
+information.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -111,10 +111,6 @@ myst_heading_anchors = 3
 # -- Options for {MyST}NB ----------------------------------------------------
 
 nb_execution_mode = "cache"
-nb_mime_priority_overrides = [
-    # builder name, mime type, priority
-    ("latex", "image/svg+xml", 15),
-]
 nb_execution_raise_on_error = True
 
 
@@ -173,69 +169,4 @@ html_theme_options = {
     "source_branch": "main",
     "source_directory": "docs/",
     "navigation_with_keys": True,
-}
-
-# -- Options for LaTeX output ------------------------------------------------
-
-numfig = True
-numfig_secnum_depth = 0
-
-sd_fontawesome_latex = True
-image_converter_args = ["-density", "300"]
-latex_engine = "pdflatex"
-latex_documents = [
-    (
-        master_doc,
-        "mqt_qcec.tex",
-        r"MQT QCEC\\{\Large A tool for Quantum Circuit Equivalence Checking}",
-        r"""Chair for Design Automation\\ Technical University of Munich, Germany\\
-        \href{mailto:quantum.cda@xcit.tum.de}{quantum.cda@xcit.tum.de}\\
-        Munich Quantum Software Company GmbH\\Garching near Munich, Germany""",
-        "howto",
-        False,
-    ),
-]
-latex_logo = "_static/mqt_dark.png"
-latex_elements = {
-    "papersize": "a4paper",
-    "releasename": "Version",
-    "printindex": r"\footnotesize\raggedright\printindex",
-    "tableofcontents": "",
-    "sphinxsetup": "iconpackage=fontawesome",
-    "extrapackages": r"\usepackage{qrcode,graphicx,calc,amsthm,etoolbox,flushend,mathtools}",
-    "preamble": r"""
-\patchcmd{\thebibliography}{\addcontentsline{toc}{section}{\refname}}{}{}{}
-\DeclarePairedDelimiter\abs{\lvert}{\rvert}
-\DeclarePairedDelimiter\mket{\lvert}{\rangle}
-\DeclarePairedDelimiter\mbra{\langle}{\rvert}
-\DeclareUnicodeCharacter{03C0}{$\pi$}
-\DeclareUnicodeCharacter{2728}{\faicon{star}}
-\DeclareUnicodeCharacter{1F6B8}{\faicon{user-plus}}
-\DeclareUnicodeCharacter{1F4DD}{\faicon{book}}
-\DeclareUnicodeCharacter{1F69A}{\faicon{truck}}
-\DeclareUnicodeCharacter{267B}{\faicon{recycle}}
-\DeclareUnicodeCharacter{2B06}{\faicon{arrow-up}}
-\DeclareUnicodeCharacter{1F4C4}{\faicon{file-alt}}
-\DeclareUnicodeCharacter{1F525}{\faicon{fire}}
-\DeclareUnicodeCharacter{1F41B}{\faicon{bug}}
-\DeclareUnicodeCharacter{1F4DA}{\faicon{book-open}}
-\DeclareUnicodeCharacter{1F4E6}{\faicon{archive}}
-\DeclareUnicodeCharacter{23EA}{\faicon{angle-double-left}}
-\DeclareUnicodeCharacter{FE0F}{}
-
-\newcommand*{\ket}[1]{\ensuremath{\mket{\mkern1mu#1}}}
-\newcommand*{\bra}[1]{\ensuremath{\mbra{\mkern1mu#1}}}
-\newtheorem{example}{Example}
-\clubpenalty=10000
-\widowpenalty=10000
-\interlinepenalty 10000
-\def\subparagraph{} % because IEEE classes don't define this, but titlesec assumes it's present
-""",
-    "extraclassoptions": r"journal, onecolumn",
-    "fvset": r"\fvset{fontsize=\small}",
-    "figure_align": "htb",
-}
-latex_domain_indices = False
-latex_docclass = {
-    "howto": "IEEEtran",
 }

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -3,11 +3,10 @@
 
 # Contributing
 
-Thank you for your interest in contributing to MQT QCEC! This document
-outlines the development guidelines and how to contribute.
+Thank you for your interest in contributing to MQT QCEC! This document outlines
+the development guidelines and how to contribute.
 
-We use GitHub to
-[host code](https://github.com/munich-quantum-toolkit/qcec), to
+We use GitHub to [host code](https://github.com/munich-quantum-toolkit/qcec), to
 [track issues and feature requests][issues], as well as accept
 [pull requests](https://github.com/munich-quantum-toolkit/qcec/pulls). See
 <https://docs.github.com/en/get-started/quickstart> for a general introduction
@@ -73,9 +72,9 @@ Contributions that do not comply with these guidelines or violate our
 - Focus on a single feature or bug at a time and only touch relevant files.
   Split multiple features into separate contributions.
 - Add tests for new features to ensure they work as intended.
-- Document new features.
-  For user-facing changes, add a changelog entry; for breaking changes, update the
-  upgrade guide. For details, see {ref}`maintaining-changelog-upgrade-guide`.
+- Document new features. For user-facing changes, add a changelog entry; for
+  breaking changes, update the upgrade guide. For details, see
+  {ref}`maintaining-changelog-upgrade-guide`.
 - Add tests for bug fixes to demonstrate the fix.
 - Document your code thoroughly and ensure it is readable.
 - Keep your code clean by removing debug statements, leftover comments, and
@@ -99,9 +98,9 @@ any AI-assisted contribution. In short:
 your PR description.
 
 If you use an agent, it will automatically read the provided {code}`AGENTS.md`,
-which contains context and instructions to help the agent work on MQT QCEC.
-For Claude Code, create a symlink with {code}`ln -s AGENTS.md CLAUDE.md` so
-Claude picks up the same file.
+which contains context and instructions to help the agent work on MQT QCEC. For
+Claude Code, create a symlink with {code}`ln -s AGENTS.md CLAUDE.md` so Claude
+picks up the same file.
 
 ### Pull Request Workflow
 
@@ -304,11 +303,11 @@ If you want to disable configuring and building the C++ tests, you can pass
 :::
 
 Our CI pipeline on GitHub also collects code coverage information and uploads it
-to [Codecov](https://codecov.io/gh/munich-quantum-toolkit/qcec). Our goal is
-to have new contributions at least maintain the current code coverage level,
-while striving for covering as much of the code as possible. Try to write
-meaningful tests that actually test the correctness of the code and not just
-exercise the code paths.
+to [Codecov](https://codecov.io/gh/munich-quantum-toolkit/qcec). Our goal is to
+have new contributions at least maintain the current code coverage level, while
+striving for covering as much of the code as possible. Try to write meaningful
+tests that actually test the correctness of the code and not just exercise the
+code paths.
 
 If you want to enable coverage locally, you can use the `coverage` preset:
 
@@ -407,21 +406,20 @@ in the {code}`bindings` directory.
 
 :::{tip}
 
-To build only the Python bindings, pass
-{code}`-DBUILD_MQT_QCEC_BINDINGS=ON` to the CMake configure step.
-CMake will then try to find Python and the necessary dependencies
-({code}`nanobind`) on your system and configure the respective targets. In
-[CLion][clion], you can enable an option to pass the current Python interpreter
-to CMake. Go to {code}`Preferences` -> {code}`Build, Execution, Deployment` ->
-{code}`CMake` -> {code}`Python Integration` and check the box
+To build only the Python bindings, pass {code}`-DBUILD_MQT_QCEC_BINDINGS=ON` to
+the CMake configure step. CMake will then try to find Python and the necessary
+dependencies ({code}`nanobind`) on your system and configure the respective
+targets. In [CLion][clion], you can enable an option to pass the current Python
+interpreter to CMake. Go to {code}`Preferences` ->
+{code}`Build, Execution, Deployment` -> {code}`CMake` ->
+{code}`Python Integration` and check the box
 {code}`Pass Python Interpreter to CMake`. Alternatively, you can pass
 {code}`-DPython_ROOT_DIR=<PATH_TO_PYTHON>` to the configure step to point CMake
 to a specific Python installation.
 
 :::
 
-The Python package itself lives in the {code}`python/mqt/qcec`
-directory.
+The Python package itself lives in the {code}`python/mqt/qcec` directory.
 
 The package lives in the {code}`src/mqt/qcec` directory.
 
@@ -443,9 +441,9 @@ These are explained in more detail in the following sections.
 ## Running the Python Tests
 
 The Python code is tested by unit tests using the
-[{code}`pytest`](https://docs.pytest.org/en/latest/) framework.
-The corresponding test files can be found in the {code}`test/python` directory.
-A {code}`nox` session is provided to conveniently run the Python tests.
+[{code}`pytest`](https://docs.pytest.org/en/latest/) framework. The
+corresponding test files can be found in the {code}`test/python` directory. A
+{code}`nox` session is provided to conveniently run the Python tests.
 
 ```console
 nox -s tests
@@ -532,11 +530,11 @@ what it does and how to use it. {code}`ruff` will check for missing docstrings
 and will explicitly warn you if you forget to add one.
 
 We heavily rely on [type hints](https://docs.python.org/3/library/typing.html)
-to document the expected types of function arguments and return values.
-For the compiled parts of the code base, we provide type hints in the form of
-stub files in the {code}`python/mqt/qcec` directory. These stub files
-are auto-generated. Do not edit them directly. Instead, you can use the
-{code}`nox` session {code}`stubs` to regenerate them automatically.
+to document the expected types of function arguments and return values. For the
+compiled parts of the code base, we provide type hints in the form of stub files
+in the {code}`python/mqt/qcec` directory. These stub files are auto-generated.
+Do not edit them directly. Instead, you can use the {code}`nox` session
+{code}`stubs` to regenerate them automatically.
 
 ```console
 nox -s stubs
@@ -665,8 +663,8 @@ implications of recent changes.
 
 ## Releasing a New Version
 
-When it is time to release a new version of MQT QCEC, create a PR that
-prepares the release. This PR should:
+When it is time to release a new version of MQT QCEC, create a PR that prepares
+the release. This PR should:
 
 - add new version titles in both the changelog and the upgrade guide,
 - add the release date to the changelog entry for the new version,
@@ -682,24 +680,22 @@ prepares the release. This PR should:
   reference to it in the changelog.
 
 Before merging the PR preparing the release, check the GitHub release draft
-generated by the Release Drafter for unlabelled PRs.
-Unlabelled PRs would appear at the top of the release draft below the main
-heading.
-If you missed updating labels before merging, you can still update them and
-re-run the Release Drafter afterward.
-Furthermore, check whether the version number in the release draft is correct.
-The version number in the release draft is dictated by the presence of certain
-labels on the PRs involved in a release. By default, a patch release will be
-created. If any PR has the {code}`minor` or {code}`major` label, a minor or
-major release will be created, respectively.
+generated by the Release Drafter for unlabelled PRs. Unlabelled PRs would appear
+at the top of the release draft below the main heading. If you missed updating
+labels before merging, you can still update them and re-run the Release Drafter
+afterward. Furthermore, check whether the version number in the release draft is
+correct. The version number in the release draft is dictated by the presence of
+certain labels on the PRs involved in a release. By default, a patch release
+will be created. If any PR has the {code}`minor` or {code}`major` label, a minor
+or major release will be created, respectively.
 
 :::{note}
 
 Sometimes, Dependabot or Renovate will tag a PR updating a dependency with a
 {code}`minor` or {code}`major` label because the dependency update itself is a
 minor or major release. This does not mean that the dependency update itself is
-a breaking change for MQT QCEC. If you are sure that the dependency update
-does not introduce any breaking changes for MQT QCEC, you can remove the
+a breaking change for MQT QCEC. If you are sure that the dependency update does
+not introduce any breaking changes for MQT QCEC, you can remove the
 {code}`minor` or {code}`major` label from the PR. This will ensure that the
 respective PR does not influence the type of an upcoming release.
 

--- a/docs/equivalence_checking.md
+++ b/docs/equivalence_checking.md
@@ -1,90 +1,151 @@
 # Quantum Circuit Equivalence Checking
 
-Consider a quantum circuit $G=g_0\dots g_{|G|-1}$ acting on $n$ qubits.
-Each gate $g_i$ of $G$ is described by a corresponding unitary matrix $U_i$ that is subsequently applied during the execution of the quantum circuit.
-Thus, the functionality of the circuit $G$ can be obtained as a unitary _system matrix_ $U$ itself by computing $U=U_{|G|-1}\dots U_0$.
+Consider a quantum circuit $G=g_0\dots g_{|G|-1}$ acting on $n$ qubits. Each
+gate $g_i$ of $G$ is described by a corresponding unitary matrix $U_i$ that is
+subsequently applied during the execution of the quantum circuit. Thus, the
+functionality of the circuit $G$ can be obtained as a unitary _system matrix_
+$U$ itself by computing $U=U_{|G|-1}\dots U_0$.
 
-The _equivalence checking problem for quantum circuits_ can be defined as follows:
+The _equivalence checking problem for quantum circuits_ can be defined as
+follows:
 
-> Given two quantum circuits $G=g_0\dots g_{|G|-1}$ and $G'=g'_0\dots g'_{|G'|-1}$ acting on the same set of qubits, do they realize the same functionality?
-> More specifically, does it hold that $U=e^{i\theta}U'$ or, equivalently $UU' = e^{i\theta} \mathbb{I}$, where $\theta\in(-\pi,\pi]$ denotes a physically unobservable global phase?
+> Given two quantum circuits $G=g_0\dots g_{|G|-1}$ and
+> $G'=g'_0\dots g'_{|G'|-1}$ acting on the same set of qubits, do they realize
+> the same functionality? More specifically, does it hold that $U=e^{i\theta}U'$
+> or, equivalently $UU' = e^{i\theta} \mathbb{I}$, where $\theta\in(-\pi,\pi]$
+> denotes a physically unobservable global phase?
 
-Conceptually, checking the equivalence of two quantum circuits is as simple as constructing and comparing the respective system matrices.
-However, the size of these matrices grows exponentially with the number of qubits, which quickly renders straight-forward methods (such as arrays) infeasible.
-Equivalence checking of quantum circuits has even been shown to be QMA-complete.
+Conceptually, checking the equivalence of two quantum circuits is as simple as
+constructing and comparing the respective system matrices. However, the size of
+these matrices grows exponentially with the number of qubits, which quickly
+renders straight-forward methods (such as arrays) infeasible. Equivalence
+checking of quantum circuits has even been shown to be QMA-complete.
 
-QCEC provides several complementary methods for efficiently tackling this challenging problem---each with their respective use cases, capabilities, and drawbacks.
+QCEC provides several complementary methods for efficiently tackling this
+challenging problem---each with their respective use cases, capabilities, and
+drawbacks.
 
 ## Construction Equivalence Checker (using Decision Diagrams)
 
-While the underlying matrices are exponentially large with respect to the number of qubits, they frequently are sparse or contain inherent redundancies.
-Decision diagrams have been proposed as a means to exploit these redundancies.
-For a detailed intro to this topic, see {cite:p}`wille2021ToolsQuantumDecisionDiagrams` and the references therein.
-In many cases, using decision diagrams allows to obtain polynomially-sized representations for the otherwise exponentially large system matrices---in the best case even linear.
+While the underlying matrices are exponentially large with respect to the number
+of qubits, they frequently are sparse or contain inherent redundancies. Decision
+diagrams have been proposed as a means to exploit these redundancies. For a
+detailed intro to this topic, see
+{cite:p}`wille2021ToolsQuantumDecisionDiagrams` and the references therein. In
+many cases, using decision diagrams allows to obtain polynomially-sized
+representations for the otherwise exponentially large system matrices---in the
+best case even linear.
 
-The functionality of both circuits is constructed by subsequently multiplying the decision diagrams representing the individual gates of $G$ and $G'$---until, eventually, decision diagram representations for the system matrices $U$ and $U'$ are obtained.
-Since decision diagrams are canonical representations of the underlying matrices, checking the equivalence of both circuits can be reduced to comparing the root pointers of the resulting decision diagrams.
+The functionality of both circuits is constructed by subsequently multiplying
+the decision diagrams representing the individual gates of $G$ and $G'$---until,
+eventually, decision diagram representations for the system matrices $U$ and
+$U'$ are obtained. Since decision diagrams are canonical representations of the
+underlying matrices, checking the equivalence of both circuits can be reduced to
+comparing the root pointers of the resulting decision diagrams.
 
-**Most effective for:** proving equivalence or non-equivalence of circuits whose functionality is sparse and/or contains redundancies.
+**Most effective for:** proving equivalence or non-equivalence of circuits whose
+functionality is sparse and/or contains redundancies.
 
 **Capable of showing:** equivalence and non-equivalence
 
-**Drawback:** Decision diagrams might still be exponentially large in the worst case.
+**Drawback:** Decision diagrams might still be exponentially large in the worst
+case.
 
 ## Alternating Equivalence Checker (using Decision Diagrams)
 
-Due to the inherent reversibility of quantum computations, equivalence checking of two circuits $G$ and $G'$ can also be reduced to proving that the composition of one circuit with the inverse of the other implements the identity, i.e., $G^{\prime -1} G = \mathbb{I}$.
-While the identity is represented by a decision diagram of linear size, sequentially constructing the representation for $G^{\prime -1} G$ still constructs the (potentially exponentially large) representation of one of the circuit's system matrix along the way.
+Due to the inherent reversibility of quantum computations, equivalence checking
+of two circuits $G$ and $G'$ can also be reduced to proving that the composition
+of one circuit with the inverse of the other implements the identity, i.e.,
+$G^{\prime -1} G = \mathbb{I}$. While the identity is represented by a decision
+diagram of linear size, sequentially constructing the representation for
+$G^{\prime -1} G$ still constructs the (potentially exponentially large)
+representation of one of the circuit's system matrix along the way.
 
-The main idea is to, instead, start with the identity $\mathbb{I}$ in between both circuits, which is symbolized by $G \rightarrow \mathbb{I} \leftarrow G'$.
-Then, gates from either circuit are applied in an alternating fashion according to some _application scheme_, with the goal of staying as close as possible to the identity.
-Given that a suitable order of execution can be determined, an efficient representation can be maintained throughout the entire verification process.
+The main idea is to, instead, start with the identity $\mathbb{I}$ in between
+both circuits, which is symbolized by $G \rightarrow \mathbb{I} \leftarrow G'$.
+Then, gates from either circuit are applied in an alternating fashion according
+to some _application scheme_, with the goal of staying as close as possible to
+the identity. Given that a suitable order of execution can be determined, an
+efficient representation can be maintained throughout the entire verification
+process.
 
 For further information on this method, see {cite:p}`burgholzer2021advanced`.
 
-**Most effective for:** proving equivalence of two circuits sharing a common structure, e.g., one circuit being a compiled or optimized version of the other.
+**Most effective for:** proving equivalence of two circuits sharing a common
+structure, e.g., one circuit being a compiled or optimized version of the other.
 
 **Capable of showing:** equivalence and non-equivalence
 
-**Drawback:** Performance depends on the availability of a suitable _application scheme_ or oracle for predicting when to apply gates from either circuit.
+**Drawback:** Performance depends on the availability of a suitable
+_application scheme_ or oracle for predicting when to apply gates from either
+circuit.
 
 ## Simulation Equivalence Checker (using Decision Diagrams)
 
-It has been shown in {cite:p}`burgholzer2021advanced`, that even small differences in quantum circuits frequently affect the entire functional representation due to the reversibility of quantum computations.
-As a consequence, simulating both circuits with a couple of arbitrary input states, i.e., considering only a small part of the whole functionality, provides an attractive alternative to the methods described above.
+It has been shown in {cite:p}`burgholzer2021advanced`, that even small
+differences in quantum circuits frequently affect the entire functional
+representation due to the reversibility of quantum computations. As a
+consequence, simulating both circuits with a couple of arbitrary input states,
+i.e., considering only a small part of the whole functionality, provides an
+attractive alternative to the methods described above.
 
-In {cite:p}`burgholzer2021randomStimuliGenerationQuantum`, several types of states have been proposed that allow to trade off efficiency versus performance:
+In {cite:p}`burgholzer2021randomStimuliGenerationQuantum`, several types of
+states have been proposed that allow to trade off efficiency versus performance:
 
-- Classical stimuli (i.e., random _computational basis states_) already offer extremely high error detection rates in general and are comparatively fast to simulate, which makes them the default.
-- Local quantum stimuli (i.e., random _single-qubit basis states_) are a little bit more computationally intensive, but provide even better error detection rates.
-- Global quantum stimuli (i.e., random _stabilizer states_) offer the highest available error detection rate, while at the same time incurring the highest computational effort.
+- Classical stimuli (i.e., random _computational basis states_) already offer
+  extremely high error detection rates in general and are comparatively fast to
+  simulate, which makes them the default.
+- Local quantum stimuli (i.e., random _single-qubit basis states_) are a little
+  bit more computationally intensive, but provide even better error detection
+  rates.
+- Global quantum stimuli (i.e., random _stabilizer states_) offer the highest
+  available error detection rate, while at the same time incurring the highest
+  computational effort.
 
-**Most effective for:** quickly detecting non-equivalence, even in cases where both circuits only differ slightly.
+**Most effective for:** quickly detecting non-equivalence, even in cases where
+both circuits only differ slightly.
 
 **Capable of showing:** non-equivalence
 
-**Drawback:** Decision diagrams for state vectors might still be exponentially large in the worst case.
+**Drawback:** Decision diagrams for state vectors might still be exponentially
+large in the worst case.
 
 ## ZX-Calculus Equivalence Checker
 
-In {cite:p}`kissinger2019PyZXLargeScale`, Kissinger and van de Wetering proposed an algorithm for optimizing quantum circuits based on ZX-calculus rewriting.
-In their initial article they also show that this rewriting approach can be used to prove the equivalence of quantum circuits.
-The idea is to construct the ZX-diagram of $G^{\prime -1} G$ and reduce this ZX-diagram using the rules of the ZX-calculus until no further rewrites can be made.
-If the resulting diagram consists only of wires (the identity ZX-diagram) then $G = G^{\prime}$. This approach has been extended in {cite:p}`peham2022equivalenceCheckingZXCalculus` to also handle ancillary qubits, floating point inaccuracies in gate parameters, as well as permutations of input and output layouts of quantum circuits.
+In {cite:p}`kissinger2019PyZXLargeScale`, Kissinger and van de Wetering proposed
+an algorithm for optimizing quantum circuits based on ZX-calculus rewriting. In
+their initial article they also show that this rewriting approach can be used to
+prove the equivalence of quantum circuits. The idea is to construct the
+ZX-diagram of $G^{\prime -1} G$ and reduce this ZX-diagram using the rules of
+the ZX-calculus until no further rewrites can be made. If the resulting diagram
+consists only of wires (the identity ZX-diagram) then $G = G^{\prime}$. This
+approach has been extended in {cite:p}`peham2022equivalenceCheckingZXCalculus`
+to also handle ancillary qubits, floating point inaccuracies in gate parameters,
+as well as permutations of input and output layouts of quantum circuits.
 
-In {cite:p}`peham2022EquivalenceCheckingParadigms`, it has been shown that equivalence checking with the ZX-calculus naturally complements equivalence checking with decision diagrams.
-Since the size of the ZX-diagram during rewriting is bounded by the size of the initial diagram, this checker can be easily executed in parallel to the aforementioned approaches based on decision diagrams.
-In cases where the size of the decision diagrams explodes, the rewriting approach can often prove equivalence much more efficiently.
+In {cite:p}`peham2022EquivalenceCheckingParadigms`, it has been shown that
+equivalence checking with the ZX-calculus naturally complements equivalence
+checking with decision diagrams. Since the size of the ZX-diagram during
+rewriting is bounded by the size of the initial diagram, this checker can be
+easily executed in parallel to the aforementioned approaches based on decision
+diagrams. In cases where the size of the decision diagrams explodes, the
+rewriting approach can often prove equivalence much more efficiently.
 
-**Most effective for:** proving equivalence of two circuits involving many rotation gates with angles of the form $\frac{\pi}{k}$ for $k\in\mathbb{N}$.
+**Most effective for:** proving equivalence of two circuits involving many
+rotation gates with angles of the form $\frac{\pi}{k}$ for $k\in\mathbb{N}$.
 
 **Capable of showing:** equivalence
 
-**Drawback:** Due to the incompleteness of the rewriting rules, this equivalence checker cannot prove non-equivalence. Furthermore, multi-controlled gates have to be decomposed prior to the equivalence check, which can quickly lead to large ZX-diagrams and slow runtimes.
+**Drawback:** Due to the incompleteness of the rewriting rules, this equivalence
+checker cannot prove non-equivalence. Furthermore, multi-controlled gates have
+to be decomposed prior to the equivalence check, which can quickly lead to large
+ZX-diagrams and slow runtimes.
 
 ## Resulting Equivalence Checking Flow
 
-QCEC implements and expands upon the flow proposed in {cite:p}`burgholzer2021advanced` as illustrated in the following figure that orchestrates all the above equivalence checkers.
+QCEC implements and expands upon the flow proposed in
+{cite:p}`burgholzer2021advanced` as illustrated in the following figure that
+orchestrates all the above equivalence checkers.
 
 ```{image} /images/verification_flow.png
 :align: center
@@ -94,6 +155,14 @@ QCEC implements and expands upon the flow proposed in {cite:p}`burgholzer2021adv
 
 In general, the following steps are performed:
 
-- First, a couple of simulation runs with random computational basis states are started. Should any of these simulations show a difference in the resulting states, the check is finished.
-- In parallel, the alternating equivalence checker is started. In case the check finishes, i.e., it does not run into a timeout, a definitive result is returned. Otherwise, if none of the simulations have shown a difference, this strongly indicates that both circuits are probably equivalent.
-- In addition to the above, the ZX-calculus equivalence checker is started. In case it finishes with an affirmative answer, the check is finished. In case it finishes and was not able to reduce the ZX-diagram to the identity, this indicates that the circuits are probably not equivalent.
+- First, a couple of simulation runs with random computational basis states are
+  started. Should any of these simulations show a difference in the resulting
+  states, the check is finished.
+- In parallel, the alternating equivalence checker is started. In case the check
+  finishes, i.e., it does not run into a timeout, a definitive result is
+  returned. Otherwise, if none of the simulations have shown a difference, this
+  strongly indicates that both circuits are probably equivalent.
+- In addition to the above, the ZX-calculus equivalence checker is started. In
+  case it finishes with an affirmative answer, the check is finished. In case it
+  finishes and was not able to reduce the ZX-diagram to the identity, this
+  indicates that the circuits are probably not equivalent.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,26 +1,19 @@
 # MQT QCEC - A tool for Quantum Circuit Equivalence Checking
 
-```{raw} latex
-\begin{abstract}
-```
+MQT QCEC is an open-source C++20 and Python library for
+{doc}`quantum circuit equivalence checking <equivalence_checking>` developed as
+part of the _{doc}`Munich Quantum Toolkit (MQT) <mqt:index>`_.
 
-MQT QCEC is an open-source C++20 and Python library for {doc}`quantum circuit equivalence checking <equivalence_checking>` developed as part of the _{doc}`Munich Quantum Toolkit (MQT) <mqt:index>`_.
-
-This documentation provides a comprehensive guide to the MQT QCEC library, including {doc}`installation instructions <installation>`, a {doc}`quickstart guide <quickstart>`, and detailed {doc}`API documentation <api/mqt/qcec/index>`.
-The source code of MQT QCEC is publicly available on GitHub at [munich-quantum-toolkit/qcec](https://github.com/munich-quantum-toolkit/qcec), while pre-built binaries are available via [PyPI](https://pypi.org/project/mqt.qcec/) for all major operating systems and all modern Python versions.
-MQT QCEC is fully compatible with Qiskit 1.0 and above.
-
-````{only} latex
-```{note}
-A live version of this document is available at [mqt.readthedocs.io/projects/qcec](https://mqt.readthedocs.io/projects/qcec).
-```
-````
-
-```{raw} latex
-\end{abstract}
-
-\sphinxtableofcontents
-```
+This documentation provides a comprehensive guide to the MQT QCEC library,
+including {doc}`installation instructions <installation>`, a
+{doc}`quickstart guide <quickstart>`, and detailed
+{doc}`API documentation <api/mqt/qcec/index>`. The source code of MQT QCEC is
+publicly available on GitHub at
+[munich-quantum-toolkit/qcec](https://github.com/munich-quantum-toolkit/qcec),
+while pre-built binaries are available via
+[PyPI](https://pypi.org/project/mqt.qcec/) for all major operating systems and
+all modern Python versions. MQT QCEC is fully compatible with Qiskit 1.0 and
+above.
 
 ```{toctree}
 :hidden:
@@ -43,7 +36,6 @@ CHANGELOG
 UPGRADING
 ```
 
-````{only} not latex
 ```{toctree}
 :maxdepth: 2
 :titlesonly:
@@ -55,7 +47,6 @@ ai_usage
 tooling
 support
 ```
-````
 
 ```{toctree}
 :hidden:
@@ -65,11 +56,15 @@ support
 api/mqt/qcec/index
 ```
 
-```{only} html
 ## Contributors and Supporters
 
-The _[Munich Quantum Toolkit (MQT)](https://mqt.readthedocs.io)_ is developed by the [Chair for Design Automation](https://www.cda.cit.tum.de/) at the [Technical University of Munich](https://www.tum.de/) and supported by [MQSC](https://mq.sc).
-Among others, it is part of the [Munich Quantum Software Stack (MQSS)](https://www.munich-quantum-valley.de/research/research-areas/mqss) ecosystem, which is being developed as part of the [Munich Quantum Valley (MQV)](https://www.munich-quantum-valley.de) initiative.
+The _[Munich Quantum Toolkit (MQT)](https://mqt.readthedocs.io)_ is developed by
+the [Chair for Design Automation](https://www.cda.cit.tum.de/) at the
+[Technical University of Munich](https://www.tum.de/) and supported by
+[MQSC](https://mq.sc). Among others, it is part of the
+[Munich Quantum Software Stack (MQSS)](https://www.munich-quantum-valley.de/research/research-areas/mqss)
+ecosystem, which is being developed as part of the
+[Munich Quantum Valley (MQV)](https://www.munich-quantum-valley.de) initiative.
 
 <div style="margin-top: 0.5em">
 <div class="only-light" align="center">
@@ -88,18 +83,21 @@ Thank you to all the contributors who have helped make MQT QCEC a reality!
 </a>
 </p>
 
-The MQT will remain free, open-source, and permissively licensed—now and in the future.
-We are firmly committed to keeping it open and actively maintained for the quantum computing community.
+The MQT will remain free, open-source, and permissively licensed—now and in the
+future. We are firmly committed to keeping it open and actively maintained for
+the quantum computing community.
 
 To support this endeavor, please consider:
 
-- Starring and sharing our repositories: [https://github.com/munich-quantum-toolkit](https://github.com/munich-quantum-toolkit)
-- Contributing code, documentation, tests, or examples via issues and pull requests
+- Starring and sharing our repositories:
+  [https://github.com/munich-quantum-toolkit](https://github.com/munich-quantum-toolkit)
+- Contributing code, documentation, tests, or examples via issues and pull
+  requests
 - Citing the MQT in your publications (see {doc}`References <references>`)
 - Using the MQT in research and teaching, and sharing feedback and use cases
-- Sponsoring us on GitHub: [https://github.com/sponsors/munich-quantum-toolkit](https://github.com/sponsors/munich-quantum-toolkit)
+- Sponsoring us on GitHub:
+  [https://github.com/sponsors/munich-quantum-toolkit](https://github.com/sponsors/munich-quantum-toolkit)
 
 <p align="center">
 <iframe src="https://github.com/sponsors/munich-quantum-toolkit/button" title="Sponsor munich-quantum-toolkit" height="32" width="114" style="border: 0; border-radius: 6px;"></iframe>
 </p>
-```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,9 +4,8 @@
 # Installation
 
 MQT QCEC is primarily developed as a C++20 library with Python bindings. The
-Python package is available on
-[PyPI](https://pypi.org/project/mqt.qcec/) and can be installed on all
-major operating systems with all
+Python package is available on [PyPI](https://pypi.org/project/mqt.qcec/) and
+can be installed on all major operating systems with all
 [officially supported Python versions](https://devguide.python.org/versions/).
 
 :::::{tip}
@@ -66,6 +65,7 @@ python -m pip install mqt.qcec
 :::
 
 ::::
+
 In most cases, no compilation is required; a platform-specific prebuilt wheel is
 downloaded and installed.
 
@@ -111,8 +111,8 @@ and [CMake](https://cmake.org/) 3.24 or newer.
 
 ## Integrating MQT QCEC into Your Project
 
-To use the MQT QCEC Python package in your project, add it as a dependency
-in your {code}`pyproject.toml` or {code}`setup.py`. This ensures the package is
+To use the MQT QCEC Python package in your project, add it as a dependency in
+your {code}`pyproject.toml` or {code}`setup.py`. This ensures the package is
 installed when your project is installed.
 
 ::::{tab-set}
@@ -157,8 +157,8 @@ either
 
 - add it as a [{code}`git` submodule][git-submodule] and build it as part of
   your project, or
-- install MQT QCEC on your system and use CMake's {code}`find_package()`
-  command to locate it, or
+- install MQT QCEC on your system and use CMake's {code}`find_package()` command
+  to locate it, or
 - use CMake's [{code}`FetchContent`][FetchContent] module to combine both
   approaches.
 
@@ -167,9 +167,9 @@ either
 :::{tab-item} {code}`FetchContent`
 
 This is the recommended approach because it lets you detect installed versions
-of MQT QCEC and only downloads the library if it is not available on the
-system. Furthermore, CMake's [{code}`FetchContent`][FetchContent] module
-provides flexibility in how the library is integrated into the project.
+of MQT QCEC and only downloads the library if it is not available on the system.
+Furthermore, CMake's [{code}`FetchContent`][FetchContent] module provides
+flexibility in how the library is integrated into the project.
 
 ```cmake
 include(FetchContent)

--- a/docs/parametrized_circuits.md
+++ b/docs/parametrized_circuits.md
@@ -10,19 +10,38 @@ mystnb:
 
 ## Variational Quantum Algorithms
 
-Variational quantum algorithms are a family of mixed quantum-classical algorithms that try to achieve a quantum advantage via low-depth circuits. This is achieved by offloading a substantial amount of computational work to a classical processor. The quantum circuits employed by variational quantum algorithms involve _parameterized gates_ which depend on some a-priori uninstantiated variable.
+Variational quantum algorithms are a family of mixed quantum-classical
+algorithms that try to achieve a quantum advantage via low-depth circuits. This
+is achieved by offloading a substantial amount of computational work to a
+classical processor. The quantum circuits employed by variational quantum
+algorithms involve _parameterized gates_ which depend on some a-priori
+uninstantiated variable.
 
-Variational quantum algorithms try to optimize the circuit's parameters in each iteration with the classical post-processor while the quantum circuit is used to compute the cost function that is being optimized. Because recompiling the quantum circuit in each of these iterations is a costly procedure, the circuit is usually compiled in _parameterized_ form in which the parameters tuned by the classical optimization routine are not bound to specific values.
+Variational quantum algorithms try to optimize the circuit's parameters in each
+iteration with the classical post-processor while the quantum circuit is used to
+compute the cost function that is being optimized. Because recompiling the
+quantum circuit in each of these iterations is a costly procedure, the circuit
+is usually compiled in _parameterized_ form in which the parameters tuned by the
+classical optimization routine are not bound to specific values.
 
-As is the case with parameter-free circuits, errors can be made during the compilation process. Therefore, verifying the correctness of compilations of parameterized quantum circuits is an important task for near-term quantum computing.
+As is the case with parameter-free circuits, errors can be made during the
+compilation process. Therefore, verifying the correctness of compilations of
+parameterized quantum circuits is an important task for near-term quantum
+computing.
 
 ## Equivalence Checking of Parameterized Quantum Circuits
 
-Having unbound parameters in a quantum circuits brings new challenges to the task of quantum circuit verification as many data structures have difficulty supporting symbolic computations directly.
-However, _ZX-diagrams_ are an exceptions to this as most rewrite rules used for equivalence checking with the _ZX-calculus_ only involve summation of parameters.
-The ZX-calculus equivalence checker in QCEC cannot be used to prove non-equivalence of quantum circuits.
-To still show non-equivalence of parameterized quantum circuits QCEC uses a scheme of repeatedly instantiating a circuits parameters in such a way as to make the check as simple as possible while still guaranteeing that either equivalence or non-equivalence can be proven.
-The resulting _equivalence checking flow_ looks as follows
+Having unbound parameters in a quantum circuits brings new challenges to the
+task of quantum circuit verification as many data structures have difficulty
+supporting symbolic computations directly. However, _ZX-diagrams_ are an
+exceptions to this as most rewrite rules used for equivalence checking with the
+_ZX-calculus_ only involve summation of parameters. The ZX-calculus equivalence
+checker in QCEC cannot be used to prove non-equivalence of quantum circuits. To
+still show non-equivalence of parameterized quantum circuits QCEC uses a scheme
+of repeatedly instantiating a circuits parameters in such a way as to make the
+check as simple as possible while still guaranteeing that either equivalence or
+non-equivalence can be proven. The resulting _equivalence checking flow_ looks
+as follows
 
 ```{image} images/parameterized_flow.svg
 :width: 90%
@@ -30,7 +49,8 @@ The resulting _equivalence checking flow_ looks as follows
 :alt: Equivalence Checking Flow for Parameterized Quantum Circuits
 ```
 
-See {cite:p}`peham2023EquivalenceCheckingParameterizedCircuits` for more information.
+See {cite:p}`peham2023EquivalenceCheckingParameterizedCircuits` for more
+information.
 
 ## Using QCEC to Verify Parameterized Quantum Circuits
 
@@ -51,7 +71,8 @@ qc_lhs.cx(0, 1)
 qc_lhs.draw(output="mpl", style="iqp")
 ```
 
-A well known commutation rule for the $R_Z$ gate, states that this circuit is equivalent to the following one
+A well known commutation rule for the $R_Z$ gate, states that this circuit is
+equivalent to the following one
 
 ```{code-cell} ipython3
 qc_rhs = QuantumCircuit(2)
@@ -62,7 +83,8 @@ qc_rhs.rz(alpha, 1)
 qc_rhs.draw(output="mpl", style="iqp")
 ```
 
-This equality can be proved with QCEC by using the {py:func}`.verify` function just as with any regular circuit
+This equality can be proved with QCEC by using the {py:func}`.verify` function
+just as with any regular circuit
 
 ```{code-cell} ipython3
 from mqt import qcec
@@ -70,8 +92,8 @@ from mqt import qcec
 qcec.verify(qc_lhs, qc_rhs)
 ```
 
-QCEC also manages to show non-equivalence of parameterized quantum circuits.
-It is easy to erroneously exchange the parameters in the above commutation rule.
+QCEC also manages to show non-equivalence of parameterized quantum circuits. It
+is easy to erroneously exchange the parameters in the above commutation rule.
 
 ```{code-cell} ipython3
 qc_rhs_err = QuantumCircuit(2)

--- a/docs/partial_equivalence.md
+++ b/docs/partial_equivalence.md
@@ -10,63 +10,93 @@ mystnb:
 
 ## Partial Equivalence vs. Total Equivalence
 
-Different definitions of quantum circuit equivalence have been proposed, with the most commonly used being total equivalence.
-Two circuits are considered totally equivalent when their matrix representations are exactly the same.
-However, it is often sufficient to consider observational equivalence, because the only way to extract information from a quantum circuit is through measurement.
-Therefore, partial equivalence has been defined, which is a weaker equality than total equivalence.
-Two circuits are considered partially equivalent if, for each possible input state, they have the same probabilities for each measurement outcome.
-In particular, partial equivalence doesn't consider qubits that are not measured or different phase angles for each measurement.
+Different definitions of quantum circuit equivalence have been proposed, with
+the most commonly used being total equivalence. Two circuits are considered
+totally equivalent when their matrix representations are exactly the same.
+However, it is often sufficient to consider observational equivalence, because
+the only way to extract information from a quantum circuit is through
+measurement. Therefore, partial equivalence has been defined, which is a weaker
+equality than total equivalence. Two circuits are considered partially
+equivalent if, for each possible input state, they have the same probabilities
+for each measurement outcome. In particular, partial equivalence doesn't
+consider qubits that are not measured or different phase angles for each
+measurement.
 
-This definition is especially useful for circuits that do not measure all of their qubits at the end, or where some qubits are initialized to a certain value at the beginning.
-We refer to the qubits that are initialized to a certain value at the beginning of the computation as _ancillary_ qubits.
-Without loss of generality, we assume that these qubits are initially set to $|0\rangle$.
-Any other initial state can be reached from the $|0\rangle$ state by applying the appropriate gates.
-The remaining qubits are the qubits that hold the input state, and they are referred to as _data_ qubits.
+This definition is especially useful for circuits that do not measure all of
+their qubits at the end, or where some qubits are initialized to a certain value
+at the beginning. We refer to the qubits that are initialized to a certain value
+at the beginning of the computation as _ancillary_ qubits. Without loss of
+generality, we assume that these qubits are initially set to $|0\rangle$. Any
+other initial state can be reached from the $|0\rangle$ state by applying the
+appropriate gates. The remaining qubits are the qubits that hold the input
+state, and they are referred to as _data_ qubits.
 
-Similarly, we differentiate between _measured_ and _garbage_ qubits.
-In order to read the output at the end of a circuit, a measurement is performed on some qubits, but not necessarily all of them.
-These qubits are the _measured_ qubits. All qubits that are not measured are called the _garbage_ qubits.
-Their final state doesn't influence the output we obtain from the computation.
+Similarly, we differentiate between _measured_ and _garbage_ qubits. In order to
+read the output at the end of a circuit, a measurement is performed on some
+qubits, but not necessarily all of them. These qubits are the _measured_ qubits.
+All qubits that are not measured are called the _garbage_ qubits. Their final
+state doesn't influence the output we obtain from the computation.
 
-For a circuit $C$ we denote $P(t | \psi, C)$ as the probability that the quantum circuit $C$ collapses to state $|t\rangle$ upon a measurement on the measured qubits,
-given that the data qubits have the initial state $|\psi\rangle$.
-Two circuits $C_1$ and $C_2$ are considered partially equivalent if, for each initial state $|\psi\rangle$ of the data qubits and each final state $|t\rangle$ of the measured qubits,
-it holds that $P(t|\psi, C_1) = P(t|\psi, C_2)$.
+For a circuit $C$ we denote $P(t | \psi, C)$ as the probability that the quantum
+circuit $C$ collapses to state $|t\rangle$ upon a measurement on the measured
+qubits, given that the data qubits have the initial state $|\psi\rangle$. Two
+circuits $C_1$ and $C_2$ are considered partially equivalent if, for each
+initial state $|\psi\rangle$ of the data qubits and each final state $|t\rangle$
+of the measured qubits, it holds that $P(t|\psi, C_1) = P(t|\psi, C_2)$.
 
 ## Checking Partial Equivalence of Quantum Circuits
 
-Partial equivalence checking is a bit more costly than regular equivalence checking.
-It is necessary to reduce the contribution of garbage qubits and normalize the phase of each measurement outcome.
-Therefore, it is not enabled by default in QCEC.
-It can be activated using an option in the configuration parameters.
-If the option `check_partial_equivalence` is set to `True`, the equivalence checker will return `equivalent` not only for totally equivalent circuits,
-but also for partially equivalent circuits. The result will be `not_equivalent` if and only if the circuits are not partially equivalent.
-On the other hand, if the option `check_partial_equivalence` is set to `False`, then the equivalence checker considers total equivalence modulo ancillary qubits.
-This means that the garbage qubits are considered as if they were measured qubits, while ancillary qubits are set to zero, as in the partial equivalence check.
-The equivalence checker will return `equivalent` for totally equivalent circuits or `equivalent_up_to_global_phase` for circuits which differ only in their global phase
-and `not_equivalent` for other circuits.
+Partial equivalence checking is a bit more costly than regular equivalence
+checking. It is necessary to reduce the contribution of garbage qubits and
+normalize the phase of each measurement outcome. Therefore, it is not enabled by
+default in QCEC. It can be activated using an option in the configuration
+parameters. If the option `check_partial_equivalence` is set to `True`, the
+equivalence checker will return `equivalent` not only for totally equivalent
+circuits, but also for partially equivalent circuits. The result will be
+`not_equivalent` if and only if the circuits are not partially equivalent. On
+the other hand, if the option `check_partial_equivalence` is set to `False`,
+then the equivalence checker considers total equivalence modulo ancillary
+qubits. This means that the garbage qubits are considered as if they were
+measured qubits, while ancillary qubits are set to zero, as in the partial
+equivalence check. The equivalence checker will return `equivalent` for totally
+equivalent circuits or `equivalent_up_to_global_phase` for circuits which differ
+only in their global phase and `not_equivalent` for other circuits.
 
-The following is a summary of the behaviour of each type of equivalence checker when the `check_partial_equivalence` option is set to `True`.
+The following is a summary of the behaviour of each type of equivalence checker
+when the `check_partial_equivalence` option is set to `True`.
 
-1. **Construction Equivalence Checker:** The construction checker supports partial equivalence checking by using decision diagrams to calculate the normalized phases of the possible outputs and then summing up the contribution of garbage qubits, in order to consider only the measurement probabilities of measured qubits.
-   Then it compares the reduced decision diagrams of the two circuits.
+1. **Construction Equivalence Checker:** The construction checker supports
+   partial equivalence checking by using decision diagrams to calculate the
+   normalized phases of the possible outputs and then summing up the
+   contribution of garbage qubits, in order to consider only the measurement
+   probabilities of measured qubits. Then it compares the reduced decision
+   diagrams of the two circuits.
 
-1. **Alternating Equivalence Checker:** The alternating checker can only be used for circuits where at least one of the two does not contain ancillary qubits.
-   It computes the composition of one circuit with the inverse of the other and verifies that the result resembles the identity.
-   When checking for partial equivalence, it suffices to verify that the result resembles the identity modulo garbage qubits.
+1. **Alternating Equivalence Checker:** The alternating checker can only be used
+   for circuits where at least one of the two does not contain ancillary qubits.
+   It computes the composition of one circuit with the inverse of the other and
+   verifies that the result resembles the identity. When checking for partial
+   equivalence, it suffices to verify that the result resembles the identity
+   modulo garbage qubits.
 
-1. **Simulation Equivalence Checker:** The simulation checker computes a representation of the state vector resulting from simulating the circuit with certain initial states.
-   Partial equivalence is enabled by summing up the contributions of garbage qubits.
+1. **Simulation Equivalence Checker:** The simulation checker computes a
+   representation of the state vector resulting from simulating the circuit with
+   certain initial states. Partial equivalence is enabled by summing up the
+   contributions of garbage qubits.
 
-1. **ZX-Calculus Equivalence Checker:** The ZX-calculus checker doesn't directly support partial equivalence, which is not a problem for the equivalence checking workflow,
-   given that the ZX-calculus checker cannot demonstrate non-equivalence of circuits due to its incompleteness.
-   Therefore it will simply output 'No Information' for circuits that are partially but not totally equivalent.
+1. **ZX-Calculus Equivalence Checker:** The ZX-calculus checker doesn't directly
+   support partial equivalence, which is not a problem for the equivalence
+   checking workflow, given that the ZX-calculus checker cannot demonstrate
+   non-equivalence of circuits due to its incompleteness. Therefore it will
+   simply output 'No Information' for circuits that are partially but not
+   totally equivalent.
 
 +++
 
 ## Using QCEC to Check for Partial Equivalence
 
-Consider the following quantum circuit with three qubits, which are all data qubits, but only one of them is measured.
+Consider the following quantum circuit with three qubits, which are all data
+qubits, but only one of them is measured.
 
 ```{code-cell} ipython3
 from qiskit import QuantumCircuit
@@ -91,8 +121,11 @@ qc_rhs.measure(0, 0)
 qc_rhs.draw(output="mpl", style="iqp")
 ```
 
-Then, these circuits are not totally equivalent, as can be shown using QCEC.
-The library even emits a handy warning in this case that indicates that two circuits have been shown to be non-equivalent, but at least one of the circuits does not measure all its qubits (i.e., has garbage qubits) and partial equivalence checking support has not been enabled.
+Then, these circuits are not totally equivalent, as can be shown using QCEC. The
+library even emits a handy warning in this case that indicates that two circuits
+have been shown to be non-equivalent, but at least one of the circuits does not
+measure all its qubits (i.e., has garbage qubits) and partial equivalence
+checking support has not been enabled.
 
 ```{code-cell} ipython3
 from mqt.qcec import verify
@@ -100,11 +133,14 @@ from mqt.qcec import verify
 verify(qc_lhs, qc_rhs)
 ```
 
-However, both circuits are partially equivalent, because they have the same probability distribution of measured values for any given initial input state.
-This equality can be proven with QCEC by enabling the `check_partial_equivalence` option:
+However, both circuits are partially equivalent, because they have the same
+probability distribution of measured values for any given initial input state.
+This equality can be proven with QCEC by enabling the
+`check_partial_equivalence` option:
 
 ```{code-cell} ipython3
 verify(qc_lhs, qc_rhs, check_partial_equivalence=True)
 ```
 
-Source: The definitions and example for partial equivalence are described in {cite:p}`chen2022PartialEquivalenceChecking`.
+Source: The definitions and example for partial equivalence are described in
+{cite:p}`chen2022PartialEquivalenceChecking`.

--- a/docs/references.md
+++ b/docs/references.md
@@ -1,16 +1,10 @@
-```{raw} latex
-\begingroup
-\renewcommand\section[1]{\endgroup}
-\phantomsection
-```
-
-````{only} html
 # References
 
-*MQT QCEC* has a strong foundation in peer‑reviewed research.
-Many of its built‑in algorithms are based on methods published in scientific journals and conferences.
-For an overview of *MQT QCEC* and its features, see {cite:p}`burgholzerQCECJKQTool2021`.
-If you want to cite this article, please use the following BibTeX entry:
+*MQT QCEC* has a strong foundation in peer‑reviewed research. Many of its
+built‑in algorithms are based on methods published in scientific journals and
+conferences. For an overview of *MQT QCEC* and its features, see
+{cite:p}`burgholzerQCECJKQTool2021`. If you want to cite this article, please
+use the following BibTeX entry:
 
 ```bibtex
 @article{burgholzerQCECJKQTool2021,
@@ -23,8 +17,9 @@ If you want to cite this article, please use the following BibTeX entry:
 }
 ```
 
-*MQT QCEC* is part of the Munich Quantum Toolkit, which is described in {cite:p}`mqt`.
-If you want to cite the Munich Quantum Toolkit, please use the following BibTeX entry:
+*MQT QCEC* is part of the Munich Quantum Toolkit, which is described in
+{cite:p}`mqt`. If you want to cite the Munich Quantum Toolkit, please use the
+following BibTeX entry:
 
 ```bibtex
 @inproceedings{mqt,
@@ -40,20 +35,27 @@ If you want to cite the Munich Quantum Toolkit, please use the following BibTeX 
 }
 ```
 
-If you use *MQT QCEC* in your work, we would appreciate if you cited {cite:p}`burgholzer2021advanced` (which subsumes {cite:p}`burgholzer2020ImprovedDDbasedEquivalence` and {cite:p}`burgholzer2020PowerSimulationEquivalence`).
+If you use *MQT QCEC* in your work, we would appreciate if you cited
+{cite:p}`burgholzer2021advanced` (which subsumes
+{cite:p}`burgholzer2020ImprovedDDbasedEquivalence` and
+{cite:p}`burgholzer2020PowerSimulationEquivalence`).
 
 Furthermore, if you use any of the particular algorithms such as
 
-- the compilation flow result verification scheme {cite:p}`burgholzer2020verifyingResultsIBM`,
-- the dedicated stimuli generation schemes {cite:p}`burgholzer2021randomStimuliGenerationQuantum`,
-- the transformation scheme for circuits containing non-unitaries {cite:p}`burgholzer2022handlingNonUnitaries`,
-- the equivalence checker based on ZX-diagrams {cite:p}`peham2022equivalenceCheckingZXCalculus`, or
-- the method for checking equivalence of parameterized circuits {cite:p}`peham2023EquivalenceCheckingParameterizedCircuits`,
+- the compilation flow result verification scheme
+  {cite:p}`burgholzer2020verifyingResultsIBM`,
+- the dedicated stimuli generation schemes
+  {cite:p}`burgholzer2021randomStimuliGenerationQuantum`,
+- the transformation scheme for circuits containing non-unitaries
+  {cite:p}`burgholzer2022handlingNonUnitaries`,
+- the equivalence checker based on ZX-diagrams
+  {cite:p}`peham2022equivalenceCheckingZXCalculus`, or
+- the method for checking equivalence of parameterized circuits
+  {cite:p}`peham2023EquivalenceCheckingParameterizedCircuits`,
 
 please consider citing their respective papers as well.
 
 A full list of references is given below.
-````
 
 ```{bibliography}
 

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -3,9 +3,9 @@
 
 # Tooling
 
-This page summarizes the main tools, software, and standards used in MQT
-QCEC. It serves as a quick reference for new contributors and users who want
-to understand the project's ecosystem.
+This page summarizes the main tools, software, and standards used in MQT QCEC.
+It serves as a quick reference for new contributors and users who want to
+understand the project's ecosystem.
 
 ## C++
 


### PR DESCRIPTION
## Description

This PR sets up [`rumdl`](https://rumdl.dev/) for linting and formatting Markdown files. Furthermore, this PR removes support for generating LaTeX documentation.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
